### PR TITLE
feat(queue): add stop functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,7 @@
 
 const Executor = require('screwdriver-executor-base');
 const Resque = require('node-resque');
-const fuses = require('circuit-fuses');
-const Breaker = fuses.breaker;
-const Fusebox = fuses.box;
+const Breaker = require('circuit-fuses').breaker;
 
 class ExecutorQueue extends Executor {
     /**
@@ -27,12 +25,7 @@ class ExecutorQueue extends Executor {
 
         // eslint-disable-next-line new-cap
         this.queue = new Resque.queue({ connection: redisConnection });
-        this.connectBreaker = new Breaker((...args) => this.queue.connect(...args), breaker);
-        this.enqueueBreaker = new Breaker((...args) => this.queue.enqueue(...args), breaker);
-
-        this.fusebox = new Fusebox();
-        this.fusebox.addFuse(this.connectBreaker);
-        this.fusebox.addFuse(this.enqueueBreaker);
+        this.breaker = new Breaker((funcName, ...args) => this.queue[funcName](...args), breaker);
     }
 
     /**
@@ -47,9 +40,31 @@ class ExecutorQueue extends Executor {
      * @return {Promise}
      */
     _start(config) {
-        return this.connectBreaker.runCommand()
+        return this.breaker.runCommand('connect')
             // Note: arguments to enqueue are [queue name, job type, array of args]
-            .then(() => this.enqueueBreaker.runCommand('builds', 'start', [config]));
+            .then(() => this.breaker.runCommand('enqueue', 'builds', 'start', [config]));
+    }
+
+    /**
+     * Stop a running or finished build
+     * @method _stop
+     * @param {Object} config               Configuration
+     * @param {Object} [config.annotations] Optional key/value object
+     * @param {String} config.buildId       Unique ID for a build
+     * @return {Promise}
+     */
+    _stop(config) {
+        return this.breaker.runCommand('connect')
+            .then(() => this.breaker.runCommand('del', 'builds', 'start', [config]))
+            .then((numDeleted) => {
+                if (numDeleted !== 0) {
+                    // Build hadn't been started, "start" event was removed from queue
+                    return null;
+                }
+
+                // "start" event has been processed, need worker to stop the executor
+                return this.breaker.runCommand('enqueue', 'builds', 'stop', [config]);
+            });
     }
 
     /**
@@ -58,7 +73,7 @@ class ExecutorQueue extends Executor {
      * @param {Response} Object     Object containing stats for the executor
      */
     stats() {
-        return this.enqueueBreaker.stats();
+        return this.breaker.stats();
     }
 }
 

--- a/test/data/stop.json
+++ b/test/data/stop.json
@@ -1,0 +1,6 @@
+{
+  "annotations": {
+    "beta.screwdriver.cd/executor": "screwdriver-executor-k8s"
+  },
+  "buildId": 8609
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -73,6 +73,16 @@ describe('index test', () => {
             assert.instanceOf(executor, Executor);
         });
 
+        it('takes in a prefix', () => {
+            executor = new Executor({
+                redisConnection: testConnection,
+                prefix: 'beta_'
+            });
+
+            assert.instanceOf(executor, Executor);
+            assert.strictEqual(executor.prefix, 'beta_');
+        });
+
         it('throws when not given a redis connection', () => {
             assert.throws(() => new Executor(), 'No redis connection passed in');
         });
@@ -138,6 +148,7 @@ describe('index test', () => {
         }).then(() => {
             assert.calledOnce(queueMock.connect);
             assert.calledWith(queueMock.del, 'builds', 'start', [testStopConfig]);
+            assert.notCalled(queueMock.enqueue);
         }));
 
         it('adds a stop event to the queue if no start events were removed', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,6 +7,8 @@ const assert = chai.assert;
 const mockery = require('mockery');
 const sinon = require('sinon');
 const testConnection = require('./data/testConnection.json');
+const testStartConfig = require('./data/start.json');
+const testStopConfig = require('./data/stop.json');
 
 sinon.assert.expose(chai.assert, { prefix: '' });
 
@@ -15,7 +17,6 @@ describe('index test', () => {
     let executor;
     let resqueMock;
     let queueMock;
-    let testJobConfig;
 
     before(() => {
         mockery.enable({
@@ -27,7 +28,8 @@ describe('index test', () => {
     beforeEach(() => {
         queueMock = {
             connect: sinon.stub().yieldsAsync(),
-            enqueue: sinon.stub().yieldsAsync()
+            enqueue: sinon.stub().yieldsAsync(),
+            del: sinon.stub().yieldsAsync(null, 1)
         };
         resqueMock = {
             queue: sinon.stub().returns(queueMock)
@@ -37,7 +39,6 @@ describe('index test', () => {
 
         /* eslint-disable global-require */
         Executor = require('../index');
-        testJobConfig = require('./data/start.json');
         /* eslint-enable global-require */
 
         executor = new Executor({
@@ -78,19 +79,6 @@ describe('index test', () => {
     });
 
     describe('_start', () => {
-        it('enqueues a build', () => executor.start({
-            annotations: {
-                'beta.screwdriver.cd/executor': 'screwdriver-executor-k8s'
-            },
-            buildId: 8609,
-            container: 'node:4',
-            apiUri: 'http://api.com',
-            token: 'asdf'
-        }).then(() => {
-            assert.calledOnce(queueMock.connect);
-            assert.calledWith(queueMock.enqueue, 'builds', 'start', [testJobConfig]);
-        }));
-
         it('rejects if it can\'t establish a connection', function () {
             queueMock.connect.yieldsAsync(new Error('couldn\'t connect'));
 
@@ -106,6 +94,64 @@ describe('index test', () => {
                 assert.fail('Should not get here');
             }, (err) => {
                 assert.instanceOf(err, Error);
+            });
+        });
+
+        it('enqueues a build', () => executor.start({
+            annotations: {
+                'beta.screwdriver.cd/executor': 'screwdriver-executor-k8s'
+            },
+            buildId: 8609,
+            container: 'node:4',
+            apiUri: 'http://api.com',
+            token: 'asdf'
+        }).then(() => {
+            assert.calledOnce(queueMock.connect);
+            assert.calledWith(queueMock.enqueue, 'builds', 'start', [testStartConfig]);
+        }));
+    });
+
+    describe('_stop', () => {
+        it('rejects if it can\'t establish a connection', function () {
+            queueMock.connect.yieldsAsync(new Error('couldn\'t connect'));
+
+            return executor.start({
+                annotations: {
+                    'beta.screwdriver.cd/executor': 'screwdriver-executor-k8s'
+                },
+                buildId: 8609,
+                container: 'node:4',
+                apiUri: 'http://api.com',
+                token: 'asdf'
+            }).then(() => {
+                assert.fail('Should not get here');
+            }, (err) => {
+                assert.instanceOf(err, Error);
+            });
+        });
+
+        it('removes a start event from the queue', () => executor.stop({
+            annotations: {
+                'beta.screwdriver.cd/executor': 'screwdriver-executor-k8s'
+            },
+            buildId: 8609
+        }).then(() => {
+            assert.calledOnce(queueMock.connect);
+            assert.calledWith(queueMock.del, 'builds', 'start', [testStopConfig]);
+        }));
+
+        it('adds a stop event to the queue if no start events were removed', () => {
+            queueMock.del.yieldsAsync(null, 0);
+
+            return executor.stop({
+                annotations: {
+                    'beta.screwdriver.cd/executor': 'screwdriver-executor-k8s'
+                },
+                buildId: 8609
+            }).then(() => {
+                assert.calledOnce(queueMock.connect);
+                assert.calledWith(queueMock.del, 'builds', 'start', [testStopConfig]);
+                assert.calledWith(queueMock.enqueue, 'builds', 'stop', [testStopConfig]);
             });
         });
     });


### PR DESCRIPTION
## Context

Currently, the executor queue does not support the ability to stop a build that is queued or already running. 

To test the stop function we also need prefixed builds so that the worker knows which API to talk to.

## Objective

When a build is told to stop, check the queue for a matching "start" job. If one is found, remove it from the queue. Otherwise add a "stop" job to the queue so that a worker can pick it up and tell the executor to stop the build.

Take in a `config.prefix` option and enqueue into different queues based on that setting.

## References

* Issue screwdriver-cd/screwdriver#693