### PR TITLE
fix(hip): Upgrade to node:8

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "Jeremiah Wuenschel <jeremiah.wuenschel@gmail.com>",
     "Min Zhang <minzhangcmu@gmail.com>",
     "Peter Peterson <jedipetey@gmail.com>",
+    "Philip Scott <pscott@zeptohost.com>",
     "Reetika Rastogi <r3rastogi@gmail.com>",
     "St. John Johnson <st.john.johnson@gmail.com",
     "Tiffany Kyi <tiffanykyi@gmail.com>"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,16 +1,15 @@
-workflow:
-    - publish
-
 shared:
-    image: node:6
+    image: node:8
 
 jobs:
     main:
+        requires: [~pr, ~commit]
         steps:
             - install: npm install
             - test: npm test
 
     publish:
+        requires: main
         steps:
             - install: npm install semantic-release
             - publish: npm run semantic-release

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -10,9 +10,7 @@ jobs:
 
     publish:
         requires: main
-        steps:
-            - install: npm install semantic-release
-            - publish: npm run semantic-release
+        template: screwdriver-cd/semantic-release
         secrets:
             # Publishing to NPM
             - NPM_TOKEN


### PR DESCRIPTION
## Context

Node.js 6 is slowly becoming deprecated, with popular packages such as `semantic-release` no longer supporting it. Aside from maintenance, upgrading to Node.js 8 also provides async functions, which simplify `Promise` control flow.

## Objective

* Change image in `screwdriver.yaml` to `node:8`
* Convert some functions that return a `Promise` to `async` functions

**Additional changes:**

* Update `screwdriver.yaml` workflow