### PR TITLE
[DNM] feat(688): Add lib function to transform cron expression

### DIFF
--- a/lib/transformCron.js
+++ b/lib/transformCron.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const parser = require('cron-parser');
+const stringHash = require('string-hash');
+
+/**
+ * Evaluate a numeric hash to a number within the range of min and max
+ *
+ * @method evaluateHash
+ * @param  {Number} hash  Hash to evaluate
+ * @param  {Number} min   Minimum evaluated value
+ * @param  {String} max   Maximum evaluated value
+ * @return {Number}       Evaluated hash
+ */
+const evaluateHash = (hash, min, max) => (hash % ((max + 1) - min)) + min;
+
+/**
+ * Transform a cron value containing a valid 'H' symbol into a valid cron value
+ * @method transformValue
+ * @param  {String} cronValue   Value to transform
+ * @param  {Number} min         Minimum acceptable value
+ * @param  {Number} max         Maximum acceptable value
+ * @param  {Number} hashValue   Numeric hash to determine new value
+ * @return {String}             Transformed cron value
+ */
+const transformValue = (cronValue, min, max, hashValue) => {
+    const values = cronValue.split(',');
+
+    // Transform each ',' seperated value
+    // Ignore values that do not have a valid 'H' symbol
+    values.forEach((value, i) => {
+        // 'H' should evaluate to some value within the range (e.g. [0-59])
+        if (value === 'H') {
+            values[i] = evaluateHash(hashValue, min, max);
+
+            return;
+        }
+
+        // e.g. H/5 -> #/5
+        if (value.match(/H\/\d+/)) {
+            values[i] = value.replace('H', evaluateHash(hashValue, min, max));
+
+            return;
+        }
+
+        // e.g. H(0-5) -> #
+        if (value.match(/H\(\d+-\d+\)/)) {
+            const newMin = Number(value.substring(2, value.lastIndexOf('-')));
+            const newMax = Number(value.substring(value.lastIndexOf('-') + 1,
+                value.lastIndexOf(')')));
+
+            // Range is invalid, throw an error
+            if (newMin < min || newMax > max || newMin > newMax) {
+                throw new Error(`${value} has an invalid range, expected range ${min}-${max}`);
+            }
+
+            values[i] = evaluateHash(hashValue, newMin, newMax);
+        }
+    });
+
+    return values.join(',');
+};
+
+/**
+ * Transform a cron expression containing valid 'H' symbol(s) into a valid cron expression
+ * @method transformCron
+ * @param  {String} cronExp Cron expression to transform
+ * @param  {Number} jobId   Job ID
+ * @return {String}         Transformed cron expression
+ */
+const transformCron = (cronExp, jobId) => {
+    const fields = cronExp.trim().split(/\s+/);
+
+    // The seconds field is not allowed (e.g. '* * * * * *')
+    if (fields.length !== 5) {
+        throw new Error(`${cronExp} does not have exactly 5 fields`);
+    }
+
+    const jobIdHash = stringHash(jobId.toString());
+
+    // Minutes [0-59]
+    // Always treat the minutes value as 'H'
+    fields[0] = transformValue('H', 0, 59, jobIdHash);
+    // Hours [0-23]
+    fields[1] = transformValue(fields[1], 0, 23, jobIdHash);
+    // Day of month [1-31]
+    fields[2] = transformValue(fields[2], 1, 31, jobIdHash);
+    // Months [1-12]
+    fields[3] = transformValue(fields[3], 1, 12, jobIdHash);
+    // Day of week [0-6]
+    fields[4] = transformValue(fields[4], 0, 6, jobIdHash);
+
+    const newCronExp = fields.join(' ');
+
+    // Perform final validation before returning
+    parser.parseExpression(newCronExp);
+
+    return newCronExp;
+};
+
+module.exports = transformCron;

--- a/package.json
+++ b/package.json
@@ -42,9 +42,11 @@
   },
   "dependencies": {
     "circuit-fuses": "^3.0.0",
+    "cron-parser": "^2.5.0",
     "ioredis": "^3.1.2",
     "node-resque": "^4.0.7",
-    "screwdriver-executor-base": "^5.2.2"
+    "screwdriver-executor-base": "^5.2.2",
+    "string-hash": "^1.1.3"
   },
   "release": {
     "debug": false,

--- a/test/lib/transformCron.test.js
+++ b/test/lib/transformCron.test.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const { assert } = require('chai');
+const transformCron = require('../../lib/transformCron.js');
+const hash = require('string-hash');
+
+const evaluateHash = (jobId, min, max) => (hash(jobId) % ((max + 1) - min)) + min;
+
+describe('transformCron', () => {
+    const jobId = '123';
+
+    // Evaluate the hashes for the default minutes and hours field
+    const minutesHash = evaluateHash(jobId, 0, 59);
+    const hoursHash = evaluateHash(jobId, 0, 23);
+
+    it('should throw if the cron expession does not have 5 fields', () => {
+        let cron;
+        // 6 fields
+
+        cron = '1 2 3 4 5 6';
+        assert.throws(() => transformCron(cron, jobId),
+            Error, '1 2 3 4 5 6 does not have exactly 5 fields');
+
+        // 4 fields
+        cron = '1 2 3 4';
+        assert.throws(() => transformCron(cron, jobId),
+            Error, '1 2 3 4 does not have exactly 5 fields');
+    });
+
+    it('should transform a cron expression with valid H symbol(s)', () => {
+        let cron;
+
+        // H * * * *
+        cron = 'H * * * *';
+        assert.deepEqual(transformCron(cron, jobId), `${minutesHash} * * * *`);
+
+        // * H/2 * * *
+        cron = '* H/2 * * *';
+        assert.deepEqual(transformCron(cron, jobId), `${minutesHash} ${hoursHash}/2 * * *`);
+
+        // * H(0-5) * * *
+        cron = '* H(0-5) * * *';
+        assert.deepEqual(transformCron(cron, jobId),
+            `${minutesHash} ${evaluateHash(jobId, 0, 5)} * * *`);
+    });
+
+    it('should throw if the cron expression has an invalid range value', () => {
+        const cron = '* H(99-100) * * *';
+
+        assert.throws(() => transformCron(cron, jobId),
+            Error, 'H(99-100) has an invalid range, expected range 0-23');
+    });
+});


### PR DESCRIPTION
This function may need to be placed elsewhere, but for the sake of reviewing I will be opening a PR here.

Essentially, this function will take in a jobID and the build periodically annotation and then transform it into a valid cron expression (or throw an error if not).

Further details are in the issue:
https://github.com/screwdriver-cd/screwdriver/issues/688