### PR TITLE
[2] fix(854): Use pipeline.admin function

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ class ExecutorQueue extends Executor {
      * @return {Promise}
      */
     async postBuildEvent({ pipeline, job, apiUri }) {
-        const jwt = await this.tokenGen(pipeline.admin
+        const jwt = this.tokenGen(pipeline.admin
             .then(realAdmin => realAdmin.username), {}, pipeline.scmContext);
 
         const options = {

--- a/index.js
+++ b/index.js
@@ -163,7 +163,8 @@ class ExecutorQueue extends Executor {
      * @return {Promise}
      */
     async postBuildEvent({ pipeline, job, apiUri }) {
-        const jwt = this.tokenGen(Object.keys(pipeline.admins)[0], {}, pipeline.scmContext);
+        const jwt = this.tokenGen(pipeline.admin
+            .then(realAdmin => realAdmin.username), {}, pipeline.scmContext);
 
         const options = {
             url: `${apiUri}/v4/events`,

--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ class ExecutorQueue extends Executor {
      * @return {Promise}
      */
     async postBuildEvent({ pipeline, job, apiUri }) {
-        const jwt = this.tokenGen(pipeline.admin
+        const jwt = await this.tokenGen(pipeline.admin
             .then(realAdmin => realAdmin.username), {}, pipeline.scmContext);
 
         const options = {

--- a/index.js
+++ b/index.js
@@ -163,8 +163,8 @@ class ExecutorQueue extends Executor {
      * @return {Promise}
      */
     async postBuildEvent({ pipeline, job, apiUri }) {
-        const jwt = this.tokenGen(pipeline.admin
-            .then(realAdmin => realAdmin.username), {}, pipeline.scmContext);
+        const admin = await pipeline.admin;
+        const jwt = this.tokenGen(admin.username, {}, pipeline.scmContext);
 
         const options = {
             url: `${apiUri}/v4/events`,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -272,6 +272,12 @@ describe('index test', () => {
 
             executor.tokenGen = tokenGen;
 
+            const adminMock = Promise.resolve({
+                username: 'test'
+            });
+
+            testDelayedConfig.pipeline.admin = adminMock;
+
             executor.startPeriodic(testDelayedConfig).then(() => {
                 assert.calledOnce(queueMock.connect);
                 assert.notCalled(redisMock.hset);


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
This pr is one of PRs to fix the issue [854](https://github.com/screwdriver-cd/screwdriver/issues/854)

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
I fixed `pipeline.admin` function to get admin who has proper permission in [this PR](https://github.com/screwdriver-cd/models/pull/247), so I fixes this repo to use the `pipeline.admin`.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/854

## Related PRs
https://github.com/screwdriver-cd/executor-queue/pull/25
https://github.com/screwdriver-cd/models/pull/247
https://github.com/screwdriver-cd/screwdriver/pull/1061