### PR TITLE
fix: args values need to be string

### DIFF
--- a/index.js
+++ b/index.js
@@ -287,7 +287,7 @@ class ExecutorQueue extends Executor {
         return this.queueBreaker.runCommand('enqueue', this.buildQueue, 'start', [{
             buildId,
             jobId,
-            blockedBy
+            blockedBy: blockedBy.toString()
         }]);
     }
 
@@ -307,7 +307,7 @@ class ExecutorQueue extends Executor {
         const numDeleted = await this.queueBreaker.runCommand('del', this.buildQueue, 'start', [{
             buildId,
             jobId,
-            blockedBy
+            blockedBy: blockedBy.toString()
         }]);
 
         if (numDeleted !== 0) {
@@ -319,7 +319,7 @@ class ExecutorQueue extends Executor {
         return this.queueBreaker.runCommand('enqueue', this.buildQueue, 'stop', [{
             buildId,
             jobId,
-            blockedBy
+            blockedBy: blockedBy.toString()
         }]);
     }
 

--- a/test/data/fullConfig.json
+++ b/test/data/fullConfig.json
@@ -7,5 +7,5 @@
   "container": "node:4",
   "apiUri": "http://api.com",
   "token": "asdf",
-  "blockedBy": [777]
+  "blockedBy": [777, 888]
 }


### PR DESCRIPTION
Currently, builds are stuck in queue. 
I checked redis and see that it's being put in the `buildConfigs` table with `blockedBy` field correctly. However, it always goes to the `failed` queue without worker picking it up:
```
1) "resque:failure-resque-retry:start:{\"buildId\":16241,\"jobId\":3220,\"blockedBy\":[3220]}"
2) "resque:resque-retry:start:{\"buildId\":16241,\"jobId\":3220,\"blockedBy\":[3220]}"
```

It's maybe because the field `blockedBy` is array and redis`rpush` does not accept that. Will make the change on the `worker` side separately. But this can be merged first. 
