### PR TITLE
fix: Revert "[2] fix(854): Use pipeline.admin function"

### DIFF
--- a/index.js
+++ b/index.js
@@ -163,8 +163,7 @@ class ExecutorQueue extends Executor {
      * @return {Promise}
      */
     async postBuildEvent({ pipeline, job, apiUri }) {
-        const admin = await pipeline.admin;
-        const jwt = this.tokenGen(admin.username, {}, pipeline.scmContext);
+        const jwt = this.tokenGen(Object.keys(pipeline.admins)[0], {}, pipeline.scmContext);
 
         const options = {
             url: `${apiUri}/v4/events`,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -276,12 +276,6 @@ describe('index test', () => {
 
             executor.tokenGen = tokenGen;
 
-            const adminMock = Promise.resolve({
-                username: 'test'
-            });
-
-            testDelayedConfig.pipeline.admin = adminMock;
-
             executor.startPeriodic(testDelayedConfig).then(() => {
                 assert.calledOnce(queueMock.connect);
                 assert.notCalled(redisMock.hset);


### PR DESCRIPTION
Build periodically is broken because of this change. When we get the pipeline model from `redis`, it lost the functions. Instead of calling the function, we can make a api call to get the working admin instead. That will come in the future.
 
Need to Reverts screwdriver-cd/executor-queue#25
