### PR TITLE
fix: add delete key to prevent race condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const winston = require('winston');
 const cron = require('./lib/cron');
 const Breaker = fuses.breaker;
 const FuseBox = fuses.box;
+const EXPIRE_TIME = 1800; // 30 mins
 
 class ExecutorQueue extends Executor {
     /**
@@ -316,7 +317,7 @@ class ExecutorQueue extends Executor {
         // Immediately after, the job gets put back to the queue, so it's always inside buildQueue
         // This key will be cleaned up automatically or when it's picked up by the worker
         await this.redisBreaker.runCommand('set', deleteKey, '');
-        await this.redisBreaker.runCommand('expire', deleteKey, 60); // expire in 1 min
+        await this.redisBreaker.runCommand('expire', deleteKey, EXPIRE_TIME);
 
         if (numDeleted !== 0) {
             // Build hadn't been started, "start" event was removed from queue

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -348,7 +348,7 @@ describe('index test', () => {
                 assert.calledWith(queueMock.del, 'builds', 'start', [partialTestConfigToString]);
                 assert.calledWith(redisMock.hdel, 'buildConfigs', buildId);
                 assert.calledWith(redisMock.set, deleteKey, '');
-                assert.calledWith(redisMock.expire, deleteKey, 60);
+                assert.calledWith(redisMock.expire, deleteKey, 1800);
                 assert.notCalled(queueMock.enqueue);
             });
         });


### PR DESCRIPTION
This is to prevent the case where a build is aborted while still in buildQueue. The job might be picked up by the worker, so it's not deleted from buildQueue. Immediately after, the job gets put back to the queue, so it's always inside buildQueue and not removed. 

Related: https://github.com/screwdriver-cd/screwdriver/issues/1110
