### PR TITLE
[1][small] fix error of toString when blockedBy is undefined

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -384,6 +384,19 @@ describe('index test', () => {
             });
         });
 
+        it('adds a stop event to the queue if it has no blocked job', () => {
+            queueMock.del.yieldsAsync(null, 0);
+            const partialTestConfigUndefined = Object.assign({}, partialTestConfig, {
+                blockedBy: undefined });
+            const stopConfig = Object.assign({ started: true }, partialTestConfigUndefined);
+
+            return executor.stop(partialTestConfigUndefined).then(() => {
+                assert.calledOnce(queueMock.connect);
+                assert.calledWith(queueMock.del, 'builds', 'start', [partialTestConfigUndefined]);
+                assert.calledWith(queueMock.enqueue, 'builds', 'stop', [stopConfig]);
+            });
+        });
+
         it('doesn\'t call connect if there\'s already a connection', () => {
             queueMock.connection.connected = true;
 


### PR DESCRIPTION
## Context
SD api cannot delete pod for the error like
```
(node:887) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'toString' of undefined
    at ExecutorQueue._stop (/usr/src/app/node_modules/screwdriver-executor-queue/index.js:328:34)
    at <anonymous>
(node:887) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:887) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

I think it needs to check it before `toString`

## Objective
API can terminate pod which has no pipeline.

## Related PR
https://github.com/screwdriver-cd/models/pull/294
