### PR TITLE
[4] feat(1270): Update build stats when in queue

### DIFF
--- a/index.js
+++ b/index.js
@@ -302,7 +302,7 @@ class ExecutorQueue extends Executor {
 
         // for backward compatibility
         if (build && build.stats) {
-            build.stats.queueTime = (new Date()).toISOString();
+            build.stats.queueEnterTime = (new Date()).toISOString();
             await build.update();
         }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -320,7 +320,7 @@ describe('index test', () => {
     });
 
     describe('_start', () => {
-        it('rejects if it can\'t establish a connection', function () {
+        it('rejects if it can\'t establish a connection', () => {
             queueMock.connect.yieldsAsync(new Error('couldn\'t connect'));
 
             return executor.start(testConfig).then(() => {
@@ -331,6 +331,13 @@ describe('index test', () => {
         });
 
         it('enqueues a build and caches the config', () => {
+            const dateNow = Date.now();
+            const isoTime = (new Date(dateNow)).toISOString();
+            const sandbox = sinon.sandbox.create({
+                useFakeTimers: false
+            });
+
+            sandbox.useFakeTimers(dateNow);
             buildMock.stats = {};
             testConfig.build = buildMock;
 
@@ -341,6 +348,8 @@ describe('index test', () => {
                 assert.calledWith(queueMock.enqueue, 'builds', 'start',
                     [partialTestConfigToString]);
                 assert.calledOnce(buildMock.update);
+                assert.equal(buildMock.stats.queueTime, isoTime);
+                sandbox.restore();
             });
         }
         );
@@ -349,7 +358,6 @@ describe('index test', () => {
             assert.calledOnce(queueMock.connect);
             assert.calledWith(redisMock.hset, 'buildConfigs', buildId,
                 JSON.stringify(testConfig));
-            assert.calledWith(queueMock.enqueue, 'builds', 'start', [partialTestConfigToString]);
             assert.calledWith(queueMock.enqueue, 'builds', 'start', [partialTestConfigToString]);
         }));
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -348,7 +348,7 @@ describe('index test', () => {
                 assert.calledWith(queueMock.enqueue, 'builds', 'start',
                     [partialTestConfigToString]);
                 assert.calledOnce(buildMock.update);
-                assert.equal(buildMock.stats.queueTime, isoTime);
+                assert.equal(buildMock.stats.queueEnterTime, isoTime);
                 sandbox.restore();
             });
         }


### PR DESCRIPTION
Objective is for the build to update its `stats` when it gets to the queue. 
Initial thought was to pass in buildFactory to executor: https://github.com/screwdriver-cd/executor-queue/commit/7968609451dc409d1536f17d4f053f35323f8d0a
However, buildFactory needs to be registered after the executor (in the API), so that will cause a circular dependency. So now we will just pass the build object instead.

Blocked by: https://github.com/screwdriver-cd/models/pull/305
Related: https://github.com/screwdriver-cd/screwdriver/issues/1270