### PR TITLE
fix: pass build object to start

### DIFF
--- a/index.js
+++ b/index.js
@@ -330,6 +330,7 @@ class ExecutorQueue extends Executor {
         }
 
         const numDeleted = await this.queueBreaker.runCommand('del', this.buildQueue, 'start', [{
+            build,
             buildId,
             jobId,
             blockedBy


### PR DESCRIPTION
[Executor-k8s checks the params](https://github.com/screwdriver-cd/executor-k8s/blob/master/index.js#L345) passed from here, not the one from models. So `executor-queue` needs to pass build object over.

Related: https://github.com/screwdriver-cd/screwdriver/issues/1270