### PR TITLE
fix(1441): Should not build periodically if job is PR

### DIFF
--- a/index.js
+++ b/index.js
@@ -230,7 +230,9 @@ class ExecutorQueue extends Executor {
                 .catch(() => Promise.resolve());
         }
 
-        if (buildCron && config.job.state === 'ENABLED' && !config.job.archived) {
+        // Do not run periodic build if job is PR
+        if (buildCron && config.job.state === 'ENABLED' && !config.job.archived &&
+            !/^PR-/.test(config.job.name)) {
             await this.connect();
 
             const next = cron.next(cron.transform(buildCron, config.job.id));


### PR DESCRIPTION
## Context
PR builds should ignore the `buildPeriodically` annotation.

## Objective
This PR skips build periodically if job is PR.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1441