### PR TITLE
fix: Pass job to _start() instead of jobId

### DIFF
--- a/test/data/fullConfig.json
+++ b/test/data/fullConfig.json
@@ -2,7 +2,10 @@
   "annotations": {
     "beta.screwdriver.cd/executor": "screwdriver-executor-k8s"
   },
-  "jobId": 777,
+  "job": {
+      "id": 777,
+      "name": "deploy"
+  },
   "buildId": 8609,
   "container": "node:4",
   "apiUri": "http://api.com",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,7 +11,8 @@ const testConnection = require('./data/testConnection.json');
 const testConfig = require('./data/fullConfig.json');
 const testPipeline = require('./data/testPipeline.json');
 const testJob = require('./data/testJob.json');
-const { buildId, jobId, blockedBy } = testConfig;
+const { buildId, blockedBy } = testConfig;
+const jobId = testConfig.job.id;
 const partialTestConfig = {
     buildId,
     jobId,
@@ -347,7 +348,7 @@ describe('index test', () => {
             testConfig.build = buildMock;
 
             return executor.start(testConfig).then(() => {
-                assert.calledTwice(queueMock.connect);
+                assert.calledOnce(queueMock.connect);
                 assert.calledWith(redisMock.hset, 'buildConfigs', buildId,
                     JSON.stringify(testConfig));
                 assert.calledWith(queueMock.enqueue, 'builds', 'start',
@@ -360,7 +361,7 @@ describe('index test', () => {
         );
 
         it('enqueues a build and caches the config', () => executor.start(testConfig).then(() => {
-            assert.calledTwice(queueMock.connect);
+            assert.calledOnce(queueMock.connect);
             assert.calledWith(redisMock.hset, 'buildConfigs', buildId,
                 JSON.stringify(testConfig));
             assert.calledWith(queueMock.enqueue, 'builds', 'start', [partialTestConfigToString]);


### PR DESCRIPTION
We need `job.name` here: https://github.com/screwdriver-cd/executor-queue/blob/master/index.js#L199

This PR fixes the _start() function to take `job` instead of `jobId`.

Requires:
https://github.com/screwdriver-cd/models/pull/328
https://github.com/screwdriver-cd/data-schema/pull/318

Tests will fail until https://github.com/screwdriver-cd/data-schema/pull/318 is merged.