### PR TITLE
fix: Allow H range in cron expression for periodic builds

### DIFF
--- a/lib/cron.js
+++ b/lib/cron.js
@@ -78,9 +78,12 @@ const transformCron = (cronExp, jobId) => {
 
     const jobIdHash = stringHash(jobId.toString());
 
+    if (fields[0] !== 'H' && !fields[0].match(/H\(\d+-\d+\)/)) {
+        fields[0] = 'H';
+    }
+
     // Minutes [0-59]
-    // Always treat the minutes value as 'H'
-    fields[0] = transformValue('H', 0, 59, jobIdHash);
+    fields[0] = transformValue(fields[0], 0, 59, jobIdHash);
     // Hours [0-23]
     fields[1] = transformValue(fields[1], 0, 23, jobIdHash);
     // Day of month [1-31]

--- a/test/lib/cron.js
+++ b/test/lib/cron.js
@@ -43,6 +43,11 @@ describe('cron', () => {
         cronExp = '* H(0-5) * * *';
         assert.deepEqual(cron.transform(cronExp, jobId),
             `${minutesHash} ${evaluateHash(jobId, 0, 5)} * * *`);
+
+        // H(0-5) * * * *
+        cronExp = 'H(0-5) * * * *';
+        assert.deepEqual(cron.transform(cronExp, jobId),
+            `${evaluateHash(jobId, 0, 5)} * * * *`);
     });
 
     it('should throw if the cron expression has an invalid range value', () => {


### PR DESCRIPTION
Some teams rely on running multiple pipelines in specific minutes of the hour. 

Previously, we only allowed `H` for the minutes field, which was a hash of the job ID. Now we allow `H(min-max)` as well, which takes into account the range provided. If you want to run your job at the 30th minute, you would use `H(30-30)`.