### PR TITLE
fix: promise request

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,12 +206,14 @@ class ExecutorQueue extends Executor {
             options.body.parentEventId = eventId;
         }
 
-        return req(options, (err, response) => {
-            if (!err && response.statusCode === 201) {
-                return Promise.resolve(response);
-            }
+        return new Promise((resolve, reject) => {
+            req(options, (err, response) => {
+                if (!err && response.statusCode === 201) {
+                    return resolve(response);
+                }
 
-            return Promise.reject(err);
+                return reject(err);
+            });
         });
     }
 
@@ -268,7 +270,7 @@ class ExecutorQueue extends Executor {
         }
 
         if (triggerBuild) {
-            await this.postBuildEvent(config)
+            return this.postBuildEvent(config)
                 .catch((err) => {
                     winston.error(`failed to post build event for job ${job.id}: ${err}`);
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "ioredis": "^3.2.2",
     "node-resque": "^4.0.9",
     "request": "^2.88.0",
-    "screwdriver-data-schema": "^18.43.3",
+    "screwdriver-data-schema": "^18.44.1",
     "screwdriver-executor-base": "^7.0.0",
     "string-hash": "^1.1.3",
     "winston": "^2.4.4"


### PR DESCRIPTION
Previously, it will not wait for request to finish. So we see this in the logs:
```

06:23:02
190308/142302.310, [response,api,events]: [1;33mpost[0m /v4/events {} [33m403[0m (2ms)
190308/142302.310, [response,api,events]: [1;33mpost[0m /v4/events
{}
[33m403[0m (2ms)

06:23:02
(node:22) UnhandledPromiseRejectionWarning: null
(node:22) UnhandledPromiseRejectionWarning: null

06:23:02
(node:22) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1036)
(node:22) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1036)
```

And we cannot see the message `failed to post build event for job...`, making it impossible to debug why the call returned `403`. 