### PR TITLE
fix: error message when response is not 201

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,9 +207,13 @@ class ExecutorQueue extends Executor {
         }
 
         return new Promise((resolve, reject) => {
-            req(options, (err, response) => {
+            req(options, (err, response, body) => {
                 if (!err && response.statusCode === 201) {
                     return resolve(response);
+                }
+
+                if (body) {
+                    return reject(body);
                 }
 
                 return reject(err);


### PR DESCRIPTION
Seeing `error: failed to post build event for job 120068: null`
