### PR TITLE
fix: split tokengen

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ class ExecutorQueue extends Executor {
         this.periodicBuildTable = `${this.prefix}periodicBuildConfigs`;
         this.frozenBuildTable = `${this.prefix}frozenBuildConfigs`;
         this.tokenGen = null;
+        this.userTokenGen = null;
         this.pipelineFactory = config.pipelineFactory;
 
         const redisConnection = Object.assign({}, config.redisConnection, { pkg: 'ioredis' });
@@ -186,7 +187,7 @@ class ExecutorQueue extends Executor {
     async postBuildEvent({ pipeline, job, apiUri, eventId }) {
         const pipelineInstance = await this.pipelineFactory.get(pipeline.id);
         const admin = await pipelineInstance.getFirstAdmin();
-        const jwt = this.tokenGen(admin.username, {}, pipeline.scmContext);
+        const jwt = this.userTokenGen(admin.username, {}, pipeline.scmContext);
 
         winston.info(`POST event for pipeline ${pipeline.id}:${job.name}` +
             `using user ${admin.username}`);
@@ -278,8 +279,8 @@ class ExecutorQueue extends Executor {
             { separator: '>' });
 
         // Save tokenGen to current executor object so we can access it in postBuildEvent
-        if (!this.tokenGen) {
-            this.tokenGen = tokenGen;
+        if (!this.userTokenGen) {
+            this.userTokenGen = tokenGen;
         }
 
         if (isUpdate) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -19,12 +19,12 @@ const partialTestConfig = {
 };
 const partialTestConfigToString = Object.assign({}, partialTestConfig, {
     blockedBy: blockedBy.toString() });
-const tokenGen = sinon.stub().returns('123456abc');
+const userTokenGen = sinon.stub().returns('admintoken');
 const testDelayedConfig = {
     pipeline: testPipeline,
     job: testJob,
     apiUri: 'http://localhost',
-    tokenGen
+    tokenGen: userTokenGen
 };
 const testAdmin = {
     username: 'admin'
@@ -312,7 +312,7 @@ describe('index test', () => {
                 url: 'http://localhost/v4/events',
                 method: 'POST',
                 headers: {
-                    Authorization: 'Bearer 123456abc',
+                    Authorization: 'Bearer admintoken',
                     'Content-Type': 'application/json'
                 },
                 json: true,
@@ -325,8 +325,6 @@ describe('index test', () => {
                 retryStrategy: executor.requestRetryStrategy
             };
 
-            executor.tokenGen = tokenGen;
-
             return executor.startPeriodic(testDelayedConfig).then(() => {
                 assert.calledOnce(queueMock.connect);
                 assert.notCalled(redisMock.hset);
@@ -335,7 +333,7 @@ describe('index test', () => {
                     jobId: testJob.id
                 }]);
                 assert.calledWith(redisMock.hdel, 'periodicBuildConfigs', testJob.id);
-
+                assert.calledOnce(userTokenGen);
                 assert.calledWith(reqMock, options);
             });
         });


### PR DESCRIPTION
Previously, both `start` and `startPeriodic` share the same tokenGen: `this.tokenGen`
However, jobFactory's tokenGen has `user` scope while buildFactory's tokenGen has `temporal` scope. So depending on which one is called first, `this.tokenGen` will be set to generate jwt with that scope. 
We need to split these two fields so that it can use the correct one. 
