### PR TITLE
fix(1058): Pass in creator and causeMessage to new event (4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 .DS_STORE
 .*.swp
 .nyc_output
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -294,7 +294,7 @@ class ExecutorQueue extends Executor {
         }
 
         if (triggerBuild) {
-            config.causeMessage = 'Started by periodic scheduler';
+            config.causeMessage = 'Started by periodic build scheduler';
 
             return this.postBuildEvent(config)
                 .catch((err) => {
@@ -357,7 +357,7 @@ class ExecutorQueue extends Executor {
             job: {
                 name: config.jobName
             },
-            causeMessage: 'Started by frozen scheduler'
+            causeMessage: 'Started by freeze window scheduler'
         };
 
         Object.assign(newConfig, config);

--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ class ExecutorQueue extends Executor {
      * @param {String} config.apiUri    Base URL of the Screwdriver API
      * @return {Promise}
      */
-    async postBuildEvent({ pipeline, job, apiUri, eventId }) {
+    async postBuildEvent({ pipeline, job, apiUri, eventId, causeMessage }) {
         const pipelineInstance = await this.pipelineFactory.get(pipeline.id);
         const admin = await pipelineInstance.getFirstAdmin();
         const jwt = this.userTokenGen(admin.username, {}, pipeline.scmContext);
@@ -201,7 +201,12 @@ class ExecutorQueue extends Executor {
             json: true,
             body: {
                 pipelineId: pipeline.id,
-                startFrom: job.name
+                startFrom: job.name,
+                creator: {
+                    name: 'Screwdriver scheduler',
+                    username: 'sd:scheduler'
+                },
+                causeMessage: causeMessage || 'Automatically started by scheduler'
             },
             maxAttempts: RETRY_LIMIT,
             retryDelay: RETRY_DELAY * 1000, // in ms
@@ -289,6 +294,8 @@ class ExecutorQueue extends Executor {
         }
 
         if (triggerBuild) {
+            config.causeMessage = 'Started by periodic scheduler';
+
             return this.postBuildEvent(config)
                 .catch((err) => {
                     winston.error(`failed to post build event for job ${job.id}: ${err}`);
@@ -349,7 +356,8 @@ class ExecutorQueue extends Executor {
         const newConfig = {
             job: {
                 name: config.jobName
-            }
+            },
+            causeMessage: 'Started by frozen scheduler'
         };
 
         Object.assign(newConfig, config);

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "chai": "^4.2.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
-    "jenkins-mocha": "^6.0.0",
+    "jenkins-mocha": "^7.0.0",
     "mockery": "^2.0.0",
     "sinon": "^4.5.0"
   },
@@ -47,7 +47,7 @@
     "ioredis": "^3.2.2",
     "node-resque": "^4.0.9",
     "requestretry": "^3.1.0",
-    "screwdriver-data-schema": "^18.44.1",
+    "screwdriver-data-schema": "^18.45.2",
     "screwdriver-executor-base": "^7.0.0",
     "string-hash": "^1.1.3",
     "winston": "^2.4.4"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -317,6 +317,8 @@ describe('index test', () => {
                 },
                 json: true,
                 body: {
+                    causeMessage: 'Started by periodic scheduler',
+                    creator: { name: 'Screwdriver scheduler', username: 'sd:scheduler' },
                     pipelineId: testDelayedConfig.pipeline.id,
                     startFrom: testDelayedConfig.job.name
                 },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -317,7 +317,7 @@ describe('index test', () => {
                 },
                 json: true,
                 body: {
-                    causeMessage: 'Started by periodic scheduler',
+                    causeMessage: 'Started by periodic build scheduler',
                     creator: { name: 'Screwdriver scheduler', username: 'sd:scheduler' },
                     pipelineId: testDelayedConfig.pipeline.id,
                     startFrom: testDelayedConfig.job.name


### PR DESCRIPTION
## Context
When an event is started by a periodic build, it can be hard for users to know if the build was started manually by a user, through a commit, or by Screwdriver automatically.

## Objective
This PR passes in `creator` and `causeMessage` when a new event is created.

_Note: I'm open to alternative `user`, `username`, `causeMessage` suggestions._

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1058
Blocked by https://github.com/screwdriver-cd/screwdriver/pull/1588