### PR TITLE
fix: filter out non-periodic jobs when doing duplicate check

### DIFF
--- a/index.js
+++ b/index.js
@@ -322,9 +322,10 @@ class ExecutorQueue extends Executor {
 
             // example job: "{\"class\":\"startDelayed\",\"queue\":\"periodicBuilds\",\"args\":[{\"jobId\":212502}]}"
             if (jobs && jobs.length > 0) {
-                const parsedJobs = jobs.maps(j => JSON.parse(j));
+                const parsedJobs = jobs.map(j => JSON.parse(j));
 
-                if (parsedJobs.find(j => j.args[0].jobId === job.id)) {
+                if (parsedJobs.find(j => j.class === 'startDelayed'
+                    && j.args[0].jobId === job.id)) {
                     return Promise.resolve();
                 }
             }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -256,6 +256,21 @@ describe('index test', () => {
                 }]);
             }));
 
+        it('do not enqueue the same delayed job in the queue', () => {
+            const job = {
+                class: 'startDelayed',
+                queue: 'periodicBuilds',
+                args: [{ jobId: testJob.id }]
+            };
+
+            redisMock.lrange = sinon.stub().yieldsAsync(null, [JSON.stringify(job)]);
+
+            return executor.startPeriodic(testDelayedConfig).then(() => {
+                assert.calledWith(cronMock.next, 'H H H H H');
+                assert.notCalled(queueMock.enqueueAt);
+            });
+        });
+
         it('stops and reEnqueues an existing job if isUpdate flag is passed', () => {
             testDelayedConfig.isUpdate = true;
 


### PR DESCRIPTION
- filter out non-periodic jobs when doing duplicate check
- we may also have blocked jobs in the same list, e.g.
```
lrange resque:delayed:1532486662 0 -1
1) "{\"class\":\"start\",\"queue\":\"builds\",\"args\":[{\"buildId\":52487,\"jobId\":8458,\"blockedBy\":\"8458\"}]}"
2) "{\"class\":\"start\",\"queue\":\"builds\",\"args\":[{\"buildId\":52559,\"jobId\":8501,\"blockedBy\":\"8501\"}]}"
```