### PR TITLE
fix: Update node-resque package

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "cron-parser": "^2.7.3",
     "hoek": "^5.0.4",
     "ioredis": "^3.2.2",
-    "node-resque": "^4.0.9",
+    "node-resque": "^5.5.3",
     "requestretry": "^3.1.0",
     "screwdriver-data-schema": "^18.45.2",
     "screwdriver-executor-base": "^7.0.0",


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
There are two components that use node-resque and its scheduler: executor-queue and queue-worker.
queue-worker uses the latest node-resque, so it cleans up old/stale workers.
https://github.com/taskrabbit/node-resque/releases/tag/v5.3.0

But executor-queue uses older node-resque without worker cleaner feature.
Overmore, executor-queue (running on api server) usually runs multiple instances and doesn't release master role. The worker cleaner function only runs on master scheduler.
https://github.com/taskrabbit/node-resque/blob/v5.3.0/lib/scheduler.js#L81-L85

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
* Upgrade node-resque to the same version as defined in queue-worker (^5.5.3) so that stale worker information are cleaned up.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/queue-worker/blob/master/package.json#L51

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
