### PR TITLE
fix: Fix resque interfaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,9 +147,9 @@ class ExecutorQueue extends Executor {
             winston.info(`scheduler became master ${state}`));
         this.scheduler.on('error', error =>
             winston.info(`scheduler error >> ${error}`));
-        this.scheduler.on('working_timestamp', timestamp =>
+        this.scheduler.on('workingTimestamp', timestamp =>
             winston.info(`scheduler working timestamp ${timestamp}`));
-        this.scheduler.on('transferred_job', (timestamp, job) =>
+        this.scheduler.on('transferredJob', (timestamp, job) =>
             winston.info(`scheduler enqueuing job timestamp  >>  ${JSON.stringify(job)}`));
 
         this.multiWorker.start();

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ class ExecutorQueue extends Executor {
         );
 
         // eslint-disable-next-line new-cap
-        this.queue = new Resque.queue({ connection: redisConnection });
+        this.queue = new Resque.Queue({ connection: redisConnection });
         this.queueBreaker = new Breaker((funcName, ...args) =>
             this.queue[funcName](...args), breaker);
         this.redisBreaker = new Breaker((funcName, ...args) =>
@@ -103,7 +103,7 @@ class ExecutorQueue extends Executor {
         };
 
         // eslint-disable-next-line new-cap
-        this.multiWorker = new Resque.multiWorker({
+        this.multiWorker = new Resque.MultiWorker({
             connection: redisConnection,
             queues: [this.periodicBuildQueue, this.frozenBuildQueue],
             minTaskProcessors: 1,
@@ -113,7 +113,7 @@ class ExecutorQueue extends Executor {
             toDisconnectProcessors: true
         }, jobs);
         // eslint-disable-next-line new-cap
-        this.scheduler = new Resque.scheduler({ connection: redisConnection });
+        this.scheduler = new Resque.Scheduler({ connection: redisConnection });
 
         this.multiWorker.on('start', workerId =>
             winston.info(`worker[${workerId}] started`));

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -86,12 +86,12 @@ describe('index test', () => {
             }
         };
         resqueMock = {
-            queue: sinon.stub().returns(queueMock),
-            multiWorker,
-            scheduler
+            Queue: sinon.stub().returns(queueMock),
+            MultiWorker: multiWorker,
+            Scheduler: scheduler
         };
-        spyMultiWorker = sinon.spy(resqueMock, 'multiWorker');
-        spyScheduler = sinon.spy(resqueMock, 'scheduler');
+        spyMultiWorker = sinon.spy(resqueMock, 'MultiWorker');
+        spyScheduler = sinon.spy(resqueMock, 'Scheduler');
         winstonMock = {
             info: sinon.stub(),
             error: sinon.stub()


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Recently I have upgraded node-resque to the latest version. #62 
But there were breaking changes between older version and new one.
I should have refer to this change: https://github.com/screwdriver-cd/queue-worker/pull/60/files#diff-168726dbe96b3ce427e7fedce31bb0bcR85

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
* Fix object name to use multiworker and scheduler properly (lower case -> upper camel case)
* Fix event name to handle scheduler events

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
