### PR TITLE
fix: fix retry plugin name

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ class ExecutorQueue extends Executor {
         const retryOptions = {
             plugins: ['Retry'],
             pluginOptions: {
-                retry: {
+                Retry: {
                     retryLimit: RETRY_LIMIT,
                     retryDelay: RETRY_DELAY
                 }

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ class ExecutorQueue extends Executor {
         this.fuseBox.addFuse(this.redisBreaker);
 
         const retryOptions = {
-            plugins: ['retry'],
+            plugins: ['Retry'],
             pluginOptions: {
                 retry: {
                     retryLimit: RETRY_LIMIT,


### PR DESCRIPTION
## Context
From node-resque 5.5.5, retry name was changed from `retry` to `Retry`.

## Objective
Fix plugin name of retry.

## References
[case for plugin file names · taskrabbit/node-resque@a331efe](https://github.com/taskrabbit/node-resque/commit/a331efe4f9b9f7b0cc66653e6238569e96ecc2c5#diff-3ecdc54e1c3f5ba5dca5d506b79e4cb8)

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
