### PR TITLE
fix: fix not to use callback to node-resque

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,25 +86,29 @@ class ExecutorQueue extends Executor {
         };
         // Jobs object to register the worker with
         const jobs = {
-            startDelayed: Object.assign({ perform: (jobConfig, callback) =>
-                this.redisBreaker.runCommand('hget', this.periodicBuildTable,
-                    jobConfig.jobId)
-                    .then(fullConfig => this.startPeriodic(Object.assign(JSON.parse(fullConfig),
-                        { triggerBuild: true })))
-                    .then(result => callback(null, result), (err) => {
-                        winston.error('err in startDelayed job: ', err);
-                        callback(err);
-                    })
-            }, retryOptions),
-            startFrozen: Object.assign({ perform: (jobConfig, callback) =>
-                this.redisBreaker.runCommand('hget', this.frozenBuildTable,
-                    jobConfig.jobId)
-                    .then(fullConfig => this.startFrozen(JSON.parse(fullConfig)))
-                    .then(result => callback(null, result), (err) => {
-                        winston.error('err in startFrozen job: ', err);
-                        callback(err);
-                    })
-            }, retryOptions)
+            startDelayed: Object.assign({ perform: async (jobConfig) => {
+                try {
+                    const fullConfig = await this.redisBreaker
+                        .runCommand('hget', this.periodicBuildTable, jobConfig.jobId);
+
+                    return await this.startPeriodic(
+                        Object.assign(JSON.parse(fullConfig), { triggerBuild: true }));
+                } catch (err) {
+                    winston.error('err in startDelayed job: ', err);
+                    throw err;
+                }
+            } }, retryOptions),
+            startFrozen: Object.assign({ perform: async (jobConfig) => {
+                try {
+                    const fullConfig = await this.redisBreaker
+                        .runCommand('hget', this.frozenBuildTable, jobConfig.jobId);
+
+                    return await this.startFrozen(JSON.parse(fullConfig));
+                } catch (err) {
+                    winston.error('err in startFrozen job: ', err);
+                    throw err;
+                }
+            } }, retryOptions)
         };
 
         // eslint-disable-next-line new-cap


### PR DESCRIPTION
## Context
node-resque 5+ uses async/await as described in README.
https://github.com/taskrabbit/node-resque/blob/master/README.md#version-notes

We fixed that problem by below PR, but still there are callbacks.
https://github.com/screwdriver-cd/executor-queue/pull/65

## Objective
Fix to use async/await.

## References
[Release v5.0.0: Async/Await · taskrabbit/node-resque](https://github.com/taskrabbit/node-resque/releases/tag/v5.0.0)

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
