### PR TITLE
fix: use async/await

### DIFF
--- a/index.js
+++ b/index.js
@@ -165,13 +165,9 @@ class ExecutorQueue extends Executor {
         Promise.resolve().then(this.scheduler.connect()).then(this.scheduler.start());
 
         process.on('SIGTERM', () => {
-            Promise.resolve().then(() => {
-                this.multiWorker.end();
-            }).catch((err) => {
+            this.multiWorker.end().catch((err) => {
                 winston.error(`failed to end the worker: ${err}`);
-            }).then(() => {
-                this.scheduler.end();
-            }).catch((err) => { // eslint-disable-line newline-per-chained-call
+            }).then(this.scheduler.end()).catch((err) => {
                 winston.error(`failed to end the scheduler: ${err}`);
                 process.exit(128);
             });

--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ class ExecutorQueue extends Executor {
             winston.info(`scheduler enqueuing job timestamp  >>  ${JSON.stringify(job)}`));
 
         this.multiWorker.start();
-        Promise.resolve().then(this.scheduler.connect()).then(this.scheduler.start());
+        Promise.resolve().then(() => this.scheduler.connect()).then(() => this.scheduler.start());
 
         process.on('SIGTERM', () => {
             this.multiWorker.end().catch((err) => {

--- a/index.js
+++ b/index.js
@@ -162,24 +162,22 @@ class ExecutorQueue extends Executor {
             winston.info(`scheduler enqueuing job timestamp  >>  ${JSON.stringify(job)}`));
 
         this.multiWorker.start();
-        this.scheduler.connect(() => {
-            this.scheduler.start();
-        });
+        await this.scheduler.connect();
+        this.scheduler.start();
 
         process.on('SIGTERM', () => {
-            this.multiWorker.end((error) => {
-                if (error) {
-                    winston.error(`failed to end the worker: ${error}`);
-                }
-
-                this.scheduler.end((err) => {
-                    if (err) {
-                        winston.error(`failed to end the scheduler: ${err}`);
-                        process.exit(128);
-                    }
-                    process.exit(0);
-                });
-            });
+            try {
+                await this.multiWorker.end();
+            } catch (err) {
+                winston.error(`failed to end the worker: ${error}`);
+            }
+            try {
+                await this.scheduler.end();
+            } catch (err) {
+                winston.error(`failed to end the scheduler: ${err}`);
+                process.exit(128);
+            }
+            process.exit(0);
         });
     }
 

--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ class ExecutorQueue extends Executor {
         );
 
         // eslint-disable-next-line new-cap
+        // queue機能を使うためにqueueに代入
         this.queue = new Resque.Queue({ connection: redisConnection });
         this.queueBreaker = new Breaker((funcName, ...args) => {
             const callback = args.pop();
@@ -326,31 +327,28 @@ class ExecutorQueue extends Executor {
                 })));
 
             // Note: arguments to enqueueAt are [timestamp, queue name, job name, array of args]
-            return new Promise((resolve) => {
-                let shouldRetry = false;
+            let shouldRetry = false;
 
-                this.queue.enqueueAt(next,
-                    this.periodicBuildQueue, 'startDelayed', [{ jobId: job.id }], (err) => {
-                        // Error thrown by node-resque if there is duplicate: https://github.com/taskrabbit/node-resque/blob/master/lib/queue.js#L65
-                        // eslint-disable-next-line max-len
-                        if (err && err.message !== 'Job already enqueued at this time with same arguments') {
-                            shouldRetry = true;
-                        }
-                    });
-
-                return resolve(shouldRetry);
-            }).then((shouldRetry) => {
+            try {
+                try {
+                    await this.queue.enqueueAt(next, this.periodicBuildQueue,
+                        'startDelayed', [{ jobId: job.id }]);
+                } catch (err) {
+                    // Error thrown by node-resque if there is duplicate: https://github.com/taskrabbit/node-resque/blob/master/lib/queue.js#L65
+                    // eslint-disable-next-line max-len
+                    if (err && err.message !== 'Job already enqueued at this time with same arguments') {
+                        shouldRetry = true;
+                    }
+                }
                 if (!shouldRetry) {
                     return Promise.resolve();
                 }
 
-                return this.queueBreaker.runCommand('enqueueAt', next,
+                await this.queueBreaker.runCommand('enqueueAt', next,
                     this.periodicBuildQueue, 'startDelayed', [{ jobId: job.id }]);
-            }).catch((err) => {
+            } catch (err) {
                 winston.error(`failed to add to delayed queue for job ${job.id}: ${err}`);
-
-                return Promise.resolve();
-            });
+            }
         }
 
         return Promise.resolve();

--- a/index.js
+++ b/index.js
@@ -57,7 +57,6 @@ class ExecutorQueue extends Executor {
         );
 
         // eslint-disable-next-line new-cap
-        // queue機能を使うためにqueueに代入
         this.queue = new Resque.Queue({ connection: redisConnection });
         this.queueBreaker = new Breaker((funcName, ...args) => {
             const callback = args.pop();

--- a/index.js
+++ b/index.js
@@ -329,20 +329,19 @@ class ExecutorQueue extends Executor {
             let shouldRetry = false;
 
             try {
-                try {
-                    await this.queue.enqueueAt(next, this.periodicBuildQueue,
-                        'startDelayed', [{ jobId: job.id }]);
-                } catch (err) {
-                    // Error thrown by node-resque if there is duplicate: https://github.com/taskrabbit/node-resque/blob/master/lib/queue.js#L65
-                    // eslint-disable-next-line max-len
-                    if (err && err.message !== 'Job already enqueued at this time with same arguments') {
-                        shouldRetry = true;
-                    }
+                await this.queue.enqueueAt(next, this.periodicBuildQueue,
+                    'startDelayed', [{ jobId: job.id }]);
+            } catch (err) {
+                // Error thrown by node-resque if there is duplicate: https://github.com/taskrabbit/node-resque/blob/master/lib/queue.js#L65
+                // eslint-disable-next-line max-len
+                if (err && err.message !== 'Job already enqueued at this time with same arguments') {
+                    shouldRetry = true;
                 }
-                if (!shouldRetry) {
-                    return Promise.resolve();
-                }
-
+            }
+            if (!shouldRetry) {
+                return Promise.resolve();
+            }
+            try {
                 await this.queueBreaker.runCommand('enqueueAt', next,
                     this.periodicBuildQueue, 'startDelayed', [{ jobId: job.id }]);
             } catch (err) {

--- a/index.js
+++ b/index.js
@@ -167,7 +167,7 @@ class ExecutorQueue extends Executor {
         process.on('SIGTERM', () => {
             this.multiWorker.end().catch((err) => {
                 winston.error(`failed to end the worker: ${err}`);
-            }).then(this.scheduler.end()).catch((err) => {
+            }).then(() => this.scheduler.end()).catch((err) => {
                 winston.error(`failed to end the scheduler: ${err}`);
                 process.exit(128);
             });

--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ class ExecutorQueue extends Executor {
             winston.info(`scheduler enqueuing job timestamp  >>  ${JSON.stringify(job)}`));
 
         this.multiWorker.start();
-        Promise.resolve().then(() => this.scheduler.connect()).then(() => this.scheduler.start());
+        this.scheduler.connect().then(() => this.scheduler.start());
 
         process.on('SIGTERM', () => {
             this.multiWorker.end().catch((err) => {

--- a/index.js
+++ b/index.js
@@ -162,22 +162,19 @@ class ExecutorQueue extends Executor {
             winston.info(`scheduler enqueuing job timestamp  >>  ${JSON.stringify(job)}`));
 
         this.multiWorker.start();
-        await this.scheduler.connect();
-        this.scheduler.start();
+        Promise.resolve().then(this.scheduler.connect()).then(this.scheduler.start());
 
         process.on('SIGTERM', () => {
-            try {
-                await this.multiWorker.end();
-            } catch (err) {
-                winston.error(`failed to end the worker: ${error}`);
-            }
-            try {
-                await this.scheduler.end();
-            } catch (err) {
+            Promise.resolve().then(() => {
+                this.multiWorker.end();
+            }).catch((err) => {
+                winston.error(`failed to end the worker: ${err}`);
+            }).then(() => {
+                this.scheduler.end();
+            }).catch((err) => { // eslint-disable-line newline-per-chained-call
                 winston.error(`failed to end the scheduler: ${err}`);
                 process.exit(128);
-            }
-            process.exit(0);
+            });
         });
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -66,12 +66,12 @@ describe('index test', () => {
         };
         multiWorker = function () {
             this.start = () => {};
-            this.end = sinon.stub();
+            this.end = sinon.stub().resolves();
         };
         scheduler = function () {
-            this.start = () => {};
-            this.connect = () => {};
-            this.end = sinon.stub();
+            this.start = sinon.stub().resolves();
+            this.connect = sinon.stub().resolves();
+            this.end = sinon.stub().resolves();
         };
         util.inherits(multiWorker, EventEmitter);
         util.inherits(scheduler, EventEmitter);


### PR DESCRIPTION
## Context
Still we use promise to use node-resque. From node resque 5.*, they require to use async/await.
https://github.com/taskrabbit/node-resque

## Objective
Not to use promise, try to use async/await

## References

https://github.com/taskrabbit/node-resque

https://github.com/taskrabbit/node-resque/blob/master/examples/scheduledJobs.js

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
