### PR TITLE
fix: spamming events when job is disabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,17 +68,11 @@ class ExecutorQueue extends Executor {
         this.redisBreaker = new Breaker((funcName, ...args) =>
             // Use the queue's built-in connection to send redis commands instead of instantiating a new one
             this.redis[funcName](...args), breaker);
-        this.requestRetryStrategy = (err, response) => {
-            console.log('---retry strategy');
-
-            return !!err || (response.statusCode !== 201 && response.statusCode !== 200);
-        };
-        this.requestRetryStrategyPostEvent = (err, response) => {
-            console.log('--- retry');
-
-            return !!err || (response.statusCode !== 201 && response.statusCode !== 200
-              && response.statusCode !== 404); // postEvent can return 404 if no job to start
-        };
+        this.requestRetryStrategy = (err, response) =>
+            !!err || (response.statusCode !== 201 && response.statusCode !== 200);
+        this.requestRetryStrategyPostEvent = (err, response) =>
+            !!err || (response.statusCode !== 201 && response.statusCode !== 200
+            && response.statusCode !== 404); // postEvent can return 404 if no job to start
         this.fuseBox = new FuseBox();
         this.fuseBox.addFuse(this.queueBreaker);
         this.fuseBox.addFuse(this.redisBreaker);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -46,6 +46,7 @@ describe('index test', () => {
     let buildMock;
     let pipelineFactoryMock;
     let fakeResponse;
+    let fakeResponse404;
     let userTokenGen;
     let testDelayedConfig;
 
@@ -113,6 +114,12 @@ describe('index test', () => {
 
         fakeResponse = {
             statusCode: 201,
+            body: {
+                id: '12345'
+            }
+        };
+        fakeResponse404 = {
+            statusCode: 404,
             body: {
                 id: '12345'
             }
@@ -337,7 +344,7 @@ describe('index test', () => {
                 },
                 maxAttempts: 3,
                 retryDelay: 5000,
-                retryStrategy: executor.requestRetryStrategy
+                retryStrategy: executor.requestRetryStrategyPostEvent
             };
 
             return executor.startPeriodic(testDelayedConfig).then(() => {
@@ -375,7 +382,7 @@ describe('index test', () => {
                 },
                 maxAttempts: 3,
                 retryDelay: 5000,
-                retryStrategy: executor.requestRetryStrategy
+                retryStrategy: executor.requestRetryStrategyPostEvent
             };
 
             return executor.startPeriodic(testDelayedConfig).then(() => {
@@ -514,6 +521,71 @@ describe('index test', () => {
                         jobId
                     }]);
                 assert.calledWith(reqMock, options);
+                sandbox.restore();
+            });
+        });
+
+        it('do not retry if delayed job is disabled', () => {
+            mockery.resetCache();
+
+            const freezeWindowsMockB = {
+                timeOutOfWindows: (windows, date) => {
+                    date.setUTCMinutes(date.getUTCMinutes() + 1);
+
+                    return date;
+                }
+            };
+
+            mockery.deregisterMock('./lib/freezeWindows');
+            mockery.registerMock('./lib/freezeWindows', freezeWindowsMockB);
+
+            /* eslint-disable global-require */
+            Executor = require('../index');
+            /* eslint-enable global-require */
+
+            executor = new Executor({
+                redisConnection: testConnection,
+                breaker: {
+                    retry: {
+                        retries: 1
+                    }
+                },
+                pipelineFactory: pipelineFactoryMock
+            });
+
+            executor.userTokenGen = userTokenGen;
+
+            const dateNow = new Date();
+
+            const sandbox = sinon.sandbox.create({
+                useFakeTimers: false
+            });
+
+            sandbox.useFakeTimers(dateNow.getTime());
+
+            const optionsPost = {
+                url: 'http://localhost/v4/events',
+                method: 'POST',
+                headers: {
+                    Authorization: 'Bearer admintoken',
+                    'Content-Type': 'application/json'
+                },
+                json: true,
+                body: {
+                    causeMessage: 'Started by freeze window scheduler',
+                    creator: { name: 'Screwdriver scheduler', username: 'sd:scheduler' },
+                    pipelineId: testDelayedConfig.pipeline.id,
+                    startFrom: testDelayedConfig.job.name
+                },
+                maxAttempts: 3,
+                retryDelay: 5000,
+                retryStrategy: executor.requestRetryStrategyPostEvent
+            };
+
+            reqMock.yieldsAsync(null, fakeResponse404, fakeResponse404.body);
+
+            return executor.startFrozen(testDelayedConfig).then(() => {
+                assert.calledWith(reqMock, optionsPost);
                 sandbox.restore();
             });
         });


### PR DESCRIPTION
When a job is frozen then disabled, it will still be added to a delayed queue. When the time is out of the freeze windows, it will make a POST to `/events`. However, since the job is disabled, it will return `404` (https://github.com/screwdriver-cd/screwdriver/blob/master/plugins/events/create.js#L203-L205), and keep retrying. 

This PR modifies the retry option so that it will not retry again. 
No test is added for testing the retry strategy directly. It doesn't seem possible. 