### PR TITLE
fix: do not store state & archived to buildconfig

### DIFF
--- a/index.js
+++ b/index.js
@@ -442,10 +442,12 @@ class ExecutorQueue extends Executor {
         });
 
         // Skip if job is disabled or archived
-        // Check if jobState & jobArchived exist first, for backward compatibility, TODO: remove later
-        if ((jobState && jobState !== 'ENABLED') || (jobArchived && jobArchived === true)) {
+
+        if (jobState === 'DISABLED' || jobArchived === true) {
             return Promise.resolve();
         }
+        delete config.jobState;
+        delete config.jobArchived;
 
         const currentTime = new Date();
         const origTime = new Date(currentTime.getTime());

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -22,6 +22,10 @@ const partialTestConfigToString = Object.assign({}, partialTestConfig, {
 const testAdmin = {
     username: 'admin'
 };
+const buildTestConfig = Object.assign({}, testConfig);
+
+delete buildTestConfig.jobState;
+delete buildTestConfig.jobArchived;
 
 const EventEmitter = require('events').EventEmitter;
 
@@ -419,7 +423,7 @@ describe('index test', () => {
             return executor.start(testConfig).then(() => {
                 assert.calledTwice(queueMock.connect);
                 assert.calledWith(redisMock.hset, 'buildConfigs', buildId,
-                    JSON.stringify(testConfig));
+                    JSON.stringify(buildTestConfig));
                 assert.calledWith(queueMock.enqueue, 'builds', 'start',
                     [partialTestConfigToString]);
                 assert.calledOnce(buildMock.update);
@@ -432,7 +436,7 @@ describe('index test', () => {
         it('enqueues a build and caches the config', () => executor.start(testConfig).then(() => {
             assert.calledTwice(queueMock.connect);
             assert.calledWith(redisMock.hset, 'buildConfigs', buildId,
-                JSON.stringify(testConfig));
+                JSON.stringify(buildTestConfig));
             assert.calledWith(queueMock.enqueue, 'builds', 'start', [partialTestConfigToString]);
         }));
 


### PR DESCRIPTION
Related: https://github.com/screwdriver-cd/screwdriver/issues/1757

API build is breaking because queue-worker is still using the old executor-router. We can re-run queue-worker to fix it. However, since we don't really need to store `state` and `archived` into our build configs, we can simply not store it.