### PR TITLE
fix: check state before postevent

### DIFF
--- a/index.js
+++ b/index.js
@@ -376,11 +376,17 @@ class ExecutorQueue extends Executor {
             causeMessage: 'Started by freeze window scheduler'
         };
 
+        if (config.jobState === 'DISABLED' || config.jobArchived === true) {
+            winston.error(`job ${config.jobName} is disabled or archived`);
+
+            return Promise.resolve();
+        }
+
         Object.assign(newConfig, config);
 
         return this.postBuildEvent(newConfig)
             .catch((err) => {
-                winston.err(`failed to post build event for job ${config.jobId}: ${err}`);
+                winston.error(`failed to post build event for job ${config.jobId}: ${err}`);
 
                 return Promise.resolve();
             });
@@ -446,8 +452,6 @@ class ExecutorQueue extends Executor {
         if (jobState === 'DISABLED' || jobArchived === true) {
             return Promise.resolve();
         }
-        delete config.jobState;
-        delete config.jobArchived;
 
         const currentTime = new Date();
         const origTime = new Date(currentTime.getTime());

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -22,11 +22,6 @@ const partialTestConfigToString = Object.assign({}, partialTestConfig, {
 const testAdmin = {
     username: 'admin'
 };
-const buildTestConfig = Object.assign({}, testConfig);
-
-delete buildTestConfig.jobState;
-delete buildTestConfig.jobArchived;
-
 const EventEmitter = require('events').EventEmitter;
 
 sinon.assert.expose(chai.assert, { prefix: '' });
@@ -423,7 +418,7 @@ describe('index test', () => {
             return executor.start(testConfig).then(() => {
                 assert.calledTwice(queueMock.connect);
                 assert.calledWith(redisMock.hset, 'buildConfigs', buildId,
-                    JSON.stringify(buildTestConfig));
+                    JSON.stringify(testConfig));
                 assert.calledWith(queueMock.enqueue, 'builds', 'start',
                     [partialTestConfigToString]);
                 assert.calledOnce(buildMock.update);
@@ -436,7 +431,7 @@ describe('index test', () => {
         it('enqueues a build and caches the config', () => executor.start(testConfig).then(() => {
             assert.calledTwice(queueMock.connect);
             assert.calledWith(redisMock.hset, 'buildConfigs', buildId,
-                JSON.stringify(buildTestConfig));
+                JSON.stringify(testConfig));
             assert.calledWith(queueMock.enqueue, 'builds', 'start', [partialTestConfigToString]);
         }));
 


### PR DESCRIPTION
When frozen job is already in queue, it will not go through regular `_start` route. Therefore, it doesn't do the check for state. Need to check it explicitly here.

Related: https://github.com/screwdriver-cd/screwdriver/issues/1757