### PR TITLE
fix(1675): Force start build if key phrase is in causeMessage [3]

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,19 +36,19 @@
     "chai": "^4.2.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
-    "jenkins-mocha": "^7.0.0",
+    "jenkins-mocha": "^8.0.0",
     "mockery": "^2.0.0",
     "sinon": "^4.5.0"
   },
   "dependencies": {
     "circuit-fuses": "^4.0.0",
-    "cron-parser": "^2.7.3",
+    "cron-parser": "^2.13.0",
     "hoek": "^5.0.4",
     "ioredis": "^3.2.2",
     "node-resque": "^5.5.3",
     "requestretry": "^3.1.0",
-    "screwdriver-data-schema": "^18.45.2",
-    "screwdriver-executor-base": "^7.0.0",
+    "screwdriver-data-schema": "^18.47.7",
+    "screwdriver-executor-base": "^7.2.1",
     "string-hash": "^1.1.3",
     "winston": "^2.4.4"
   },


### PR DESCRIPTION
## Context

Sometimes users want to push out a build even if it is FROZEN.

## Objective

This PR starts a build even if it should be FROZEN by checking if the causeMessage matches `[force start]`.

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1675
Blocked by https://github.com/screwdriver-cd/data-schema/pull/360, https://github.com/screwdriver-cd/models/pull/398

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
