### PR TITLE
feat(1610): Add cleanup method to executor-q

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -611,9 +611,9 @@ describe('index test', () => {
     describe('cleanUp', () => {
         it('worker.end() is called', () => {
             executor.cleanUp().then(() => {
-                assert.calledWith(spyMultiWorker);
-                assert.calledWith(spyScheduler);
-                assert.calledWith(queueMock.end);
+                assert.called(spyMultiWorker);
+                assert.called(spyScheduler);
+                assert.called(queueMock.end);
             });
         });
     });


### PR DESCRIPTION
## Context

Currently when the node process terminates it happens abruptly and the in process messages are lost

## Objective

This PR adds a cleanup function to be executed which ends workers and queues on termination request via the shutdown plugin

## References

https://github.com/screwdriver-cd/screwdriver/issues/1610

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
