### PR TITLE
fix(1839): Add enqueueTime to buildConfig

### DIFF
--- a/index.js
+++ b/index.js
@@ -509,7 +509,7 @@ class ExecutorQueue extends Executor {
                 }]
             );
         } else {
-            //set the start time in the queue
+            // set the start time in the queue
             Object.assign(config, { enqueueTime: new Date() });
             // Store the config in redis
             await this.redisBreaker.runCommand('hset', this.buildConfigTable,

--- a/index.js
+++ b/index.js
@@ -509,6 +509,8 @@ class ExecutorQueue extends Executor {
                 }]
             );
         } else {
+            //set the start time in the queue
+            Object.assign(config, { enqueueTime: new Date() });
             // Store the config in redis
             await this.redisBreaker.runCommand('hset', this.buildConfigTable,
                 buildId, JSON.stringify(config));

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "ioredis": "^3.2.2",
     "node-resque": "^5.5.3",
     "requestretry": "^3.1.0",
-    "screwdriver-data-schema": "^18.47.7",
-    "screwdriver-executor-base": "^7.2.1",
+    "screwdriver-data-schema": "^19.1.1",
+    "screwdriver-executor-base": "^7.4.0",
     "string-hash": "^1.1.3",
     "screwdriver-logger": "^1.0.0"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -446,8 +446,21 @@ describe('index test', () => {
                 assert.equal(buildMock.stats.queueEnterTime, isoTime);
                 sandbox.restore();
             });
-        }
-        );
+        });
+
+        it('enqueues a build and with enqueueTime', () => {
+            buildMock.stats = {};
+            testConfig.build = buildMock;
+            const config = Object.assign({}, testConfig, { enqueueTime: new Date() });
+
+            return executor.start(config).then(() => {
+                assert.calledTwice(queueMock.connect);
+                assert.calledWith(redisMock.hset, 'buildConfigs', buildId,
+                    JSON.stringify(config));
+                assert.calledWith(queueMock.enqueue, 'builds', 'start',
+                    [partialTestConfigToString]);
+            });
+        });
 
         it('enqueues a build and caches the config', () => executor.start(testConfig).then(() => {
             assert.calledTwice(queueMock.connect);


### PR DESCRIPTION
## Context

Add enqueueTime to buildConfig which can be read by the worker

## Objective

To identify the build runtime and compare with timeout we need the time when build was pushed to queue.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1839

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
