### PR TITLE
fix(1839): Store exact build start time in redis hash

### DIFF
--- a/index.js
+++ b/index.js
@@ -479,7 +479,6 @@ class ExecutorQueue extends Executor {
             const data = await this.redisBreaker.runCommand('hget', this.timeoutQueue,
                 config.buildId);
 
-            console.log(data);
             if (!data) {
                 return Promise.resolve();
             }

--- a/index.js
+++ b/index.js
@@ -509,7 +509,7 @@ class ExecutorQueue extends Executor {
                 }]
             );
         } else {
-            //set the start time in the queue
+            // set the start time in the queue
             Object.assign(config, { enqueueTime: new Date() });
             // Store the config in redis
             await this.redisBreaker.runCommand('hset', this.buildConfigTable,

--- a/index.js
+++ b/index.js
@@ -509,6 +509,8 @@ class ExecutorQueue extends Executor {
                 }]
             );
         } else {
+            //set the start time in the queue
+            Object.assign(config, { enqueueTime: new Date() });
             // Store the config in redis
             await this.redisBreaker.runCommand('hset', this.buildConfigTable,
                 buildId, JSON.stringify(config));

--- a/index.js
+++ b/index.js
@@ -421,7 +421,12 @@ class ExecutorQueue extends Executor {
 
     /**
      * Adds start time of a build to timeout queue
-     * @param {Object} config
+     * @method status
+     * @param  {Object} config               Configuration
+     * @param  {String} config.buildId       Unique ID for a build
+     * @param  {String} config.startTime     Start time fo build
+     * @param  {String} config.buildStatus     Status of build
+     * @return {Promise}
      */
     async _startTimer(config) {
         try {
@@ -462,7 +467,10 @@ class ExecutorQueue extends Executor {
 
     /**
      * Removes start time info key from timeout queue
-     * @param {Object} config
+     * @method status
+     * @param  {Object} config               Configuration
+     * @param  {String} config.buildId       Unique ID for a build
+     * @return {Promise}
      */
     async _stopTimer(config) {
         try {

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "ioredis": "^3.2.2",
     "node-resque": "^5.5.3",
     "requestretry": "^3.1.0",
-    "screwdriver-data-schema": "^18.47.7",
-    "screwdriver-executor-base": "^7.2.1",
+    "screwdriver-data-schema": "^19.1.1",
+    "screwdriver-executor-base": "^7.4.0",
     "string-hash": "^1.1.3",
     "screwdriver-logger": "^1.0.0"
   },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -670,12 +670,11 @@ describe('index test', () => {
             };
 
             sandbox.useFakeTimers(dateNow);
-            redisMock.hget.withArgs('timeoutConfigs', buildId)
-                .resolves(JSON.stringify({
-                    jobId,
-                    startTime: isoTime,
-                    timeout: 90
-                }));
+            redisMock.hget.withArgs('timeoutConfigs', buildId).yieldsAsync(null, {
+                buildId,
+                jobId,
+                startTime: isoTime
+            });
 
             await executor.stopTimer(timerConfig);
 
@@ -686,7 +685,7 @@ describe('index test', () => {
 
         it('hdel is not called if buildId does not exist in cache', async () => {
             redisMock.hget.withArgs('timeoutConfigs', buildId)
-                .resolves(null);
+                .yieldsAsync(null, null);
 
             await executor.stopTimer(testConfig);
             assert.calledOnce(queueMock.connect);
@@ -719,8 +718,7 @@ describe('index test', () => {
             };
 
             sandbox.useFakeTimers(dateNow);
-            redisMock.hget.resolves(null);
-
+            redisMock.hget.yieldsAsync(null, null);
             await executor.startTimer(timerConfig);
             assert.calledOnce(queueMock.connect);
             assert.calledWith(redisMock.hset, 'timeoutConfigs', buildId,
@@ -747,7 +745,7 @@ describe('index test', () => {
             };
 
             sandbox.useFakeTimers(dateNow);
-            redisMock.hget.resolves(null);
+            redisMock.hget.yieldsAsync(null, null);
 
             await executor.startTimer(timerConfig);
             assert.calledOnce(queueMock.connect);
@@ -770,12 +768,11 @@ describe('index test', () => {
             };
 
             sandbox.useFakeTimers(dateNow);
-            redisMock.hget.withArgs('timeoutConfigs', buildId)
-                .resolves(JSON.stringify({
-                    jobId,
-                    startTime: isoTime,
-                    timeout: 90
-                }));
+            redisMock.hget.withArgs('timeoutConfigs', buildId).yieldsAsync({
+                jobId,
+                startTime: isoTime,
+                timeout: 90
+            });
 
             await executor.startTimer(timerConfig);
             assert.calledOnce(queueMock.connect);
@@ -802,8 +799,7 @@ describe('index test', () => {
                 };
 
                 sandbox.useFakeTimers(dateNow);
-                redisMock.hget.resolves(null);
-
+                redisMock.hget.yieldsAsync(null, null);
                 await executor.startTimer(timerConfig);
                 assert.calledOnce(queueMock.connect);
                 assert.calledWith(redisMock.hset, 'timeoutConfigs', buildId,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -446,8 +446,21 @@ describe('index test', () => {
                 assert.equal(buildMock.stats.queueEnterTime, isoTime);
                 sandbox.restore();
             });
-        }
-        );
+        });
+
+        it('enqueues a build and with enqueueTime', () => {
+            buildMock.stats = {};
+            testConfig.build = buildMock;
+            const config = Object.assign({}, testConfig, { enqueueTime: new Date() });
+
+            return executor.start(config).then(() => {
+                assert.calledTwice(queueMock.connect);
+                assert.calledWith(redisMock.hset, 'buildConfigs', buildId,
+                    JSON.stringify(config));
+                assert.calledWith(queueMock.enqueue, 'builds', 'start',
+                    [partialTestConfigToString]);
+            });
+        });
 
         it('enqueues a build and caches the config', () => executor.start(testConfig).then(() => {
             assert.calledTwice(queueMock.connect);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -96,7 +96,8 @@ describe('index test', () => {
             hdel: sinon.stub().yieldsAsync(),
             hset: sinon.stub().yieldsAsync(),
             set: sinon.stub().yieldsAsync(),
-            expire: sinon.stub().yieldsAsync()
+            expire: sinon.stub().yieldsAsync(),
+            hget: sinon.stub().yieldsAsync()
         };
         redisConstructorMock = sinon.stub().returns(redisMock);
         cronMock = {
@@ -462,12 +463,14 @@ describe('index test', () => {
             });
         });
 
-        it('enqueues a build and caches the config', () => executor.start(testConfig).then(() => {
-            assert.calledTwice(queueMock.connect);
-            assert.calledWith(redisMock.hset, 'buildConfigs', buildId,
-                JSON.stringify(testConfig));
-            assert.calledWith(queueMock.enqueue, 'builds', 'start', [partialTestConfigToString]);
-        }));
+        it('enqueues a build and caches the config', () =>
+            executor.start(testConfig).then(() => {
+                assert.calledTwice(queueMock.connect);
+                assert.calledWith(redisMock.hset, 'buildConfigs', buildId,
+                    JSON.stringify(testConfig));
+                assert.calledWith(queueMock.enqueue, 'builds', 'start',
+                    [partialTestConfigToString]);
+            }));
 
         it('doesn\'t call connect if there\'s already a connection', () => {
             queueMock.connection.connected = true;
@@ -641,5 +644,175 @@ describe('index test', () => {
                 }
             });
         });
+    });
+
+    describe('_stopTimer', () => {
+        it('does not reject if it can\'t establish a connection', async () => {
+            queueMock.connect.rejects(new Error('couldn\'t connect'));
+            try {
+                await executor.stopTimer({});
+            } catch (err) {
+                assert.fail('Should not get here');
+            }
+        });
+
+        it('removes a key from redis for the specified buildId if it exists', async () => {
+            const dateNow = Date.now();
+            const isoTime = (new Date(dateNow)).toISOString();
+            const sandbox = sinon.sandbox.create({
+                useFakeTimers: false
+            });
+
+            const timerConfig = {
+                buildId,
+                jobId,
+                startTime: isoTime
+            };
+
+            sandbox.useFakeTimers(dateNow);
+            redisMock.hget.withArgs('timeoutConfigs', buildId)
+                .resolves(JSON.stringify({
+                    jobId,
+                    startTime: isoTime,
+                    timeout: 90
+                }));
+
+            await executor.stopTimer(timerConfig);
+
+            assert.calledOnce(queueMock.connect);
+            assert.calledWith(redisMock.hdel, 'timeoutConfigs', buildId);
+            sandbox.restore();
+        });
+
+        it('hdel is not called if buildId does not exist in cache', async () => {
+            redisMock.hget.withArgs('timeoutConfigs', buildId)
+                .resolves(null);
+
+            await executor.stopTimer(testConfig);
+            assert.calledOnce(queueMock.connect);
+            assert.notCalled(redisMock.hdel);
+        });
+    });
+
+    describe('_startTimer', () => {
+        it('does not reject if it can\'t establish a connection', async () => {
+            queueMock.connect.rejects(new Error('couldn\'t connect'));
+            try {
+                await executor.startTimer({});
+            } catch (err) {
+                assert.fail('Should not get here');
+            }
+        });
+
+        it('adds a timeout key if status is RUNNING and caches the config', async () => {
+            const dateNow = Date.now();
+            const isoTime = (new Date(dateNow)).toISOString();
+            const sandbox = sinon.sandbox.create({
+                useFakeTimers: false
+            });
+
+            const timerConfig = {
+                buildId,
+                jobId,
+                buildStatus: 'RUNNING',
+                startTime: isoTime
+            };
+
+            sandbox.useFakeTimers(dateNow);
+            redisMock.hget.resolves(null);
+
+            await executor.startTimer(timerConfig);
+            assert.calledOnce(queueMock.connect);
+            assert.calledWith(redisMock.hset, 'timeoutConfigs', buildId,
+                JSON.stringify({
+                    jobId,
+                    startTime: isoTime,
+                    timeout: 90
+                }));
+            sandbox.restore();
+        });
+
+        it('does not add a timeout key if status is !RUNNING', async () => {
+            const dateNow = Date.now();
+            const isoTime = (new Date(dateNow)).toISOString();
+            const sandbox = sinon.sandbox.create({
+                useFakeTimers: false
+            });
+
+            const timerConfig = {
+                buildId,
+                jobId,
+                buildStatus: 'QUEUED',
+                startTime: isoTime
+            };
+
+            sandbox.useFakeTimers(dateNow);
+            redisMock.hget.resolves(null);
+
+            await executor.startTimer(timerConfig);
+            assert.calledOnce(queueMock.connect);
+            assert.notCalled(redisMock.hset);
+            sandbox.restore();
+        });
+
+        it('does not add a timeout key if buildId already exists', async () => {
+            const dateNow = Date.now();
+            const isoTime = (new Date(dateNow)).toISOString();
+            const sandbox = sinon.sandbox.create({
+                useFakeTimers: false
+            });
+
+            const timerConfig = {
+                buildId,
+                jobId,
+                buildStatus: 'QUEUED',
+                startTime: isoTime
+            };
+
+            sandbox.useFakeTimers(dateNow);
+            redisMock.hget.withArgs('timeoutConfigs', buildId)
+                .resolves(JSON.stringify({
+                    jobId,
+                    startTime: isoTime,
+                    timeout: 90
+                }));
+
+            await executor.startTimer(timerConfig);
+            assert.calledOnce(queueMock.connect);
+            assert.notCalled(redisMock.hset);
+            sandbox.restore();
+        });
+
+        it('adds a timeout config with specific timeout when annotations present',
+            async () => {
+                const dateNow = Date.now();
+                const isoTime = (new Date(dateNow)).toISOString();
+                const sandbox = sinon.sandbox.create({
+                    useFakeTimers: false
+                });
+
+                const timerConfig = {
+                    buildId,
+                    jobId,
+                    buildStatus: 'RUNNING',
+                    startTime: isoTime,
+                    annotations: {
+                        'screwdriver.cd/timeout': 5
+                    }
+                };
+
+                sandbox.useFakeTimers(dateNow);
+                redisMock.hget.resolves(null);
+
+                await executor.startTimer(timerConfig);
+                assert.calledOnce(queueMock.connect);
+                assert.calledWith(redisMock.hset, 'timeoutConfigs', buildId,
+                    JSON.stringify({
+                        jobId,
+                        startTime: isoTime,
+                        timeout: 5
+                    }));
+                sandbox.restore();
+            });
     });
 });


### PR DESCRIPTION
## Context

To fix the build timeout we need to know the exact start time of a build

## Objective

This PR will implement two methods to store the build start time in a redis hash when build is started and clear it when build is stopped

## References

https://github.com/screwdriver-cd/screwdriver/issues/1839

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
