### PR TITLE
fix: freeze window losing previous build context

### DIFF
--- a/index.js
+++ b/index.js
@@ -191,12 +191,13 @@ class ExecutorQueue extends Executor {
      * @method postBuildEvent
      * @param {Object} config           Configuration
      * @param {Number} [config.eventId] Optional Parent event ID (optional)
+     * @param {Number} config.buildId   Freezed build id
      * @param {Object} config.pipeline  Pipeline of the job
      * @param {Object} config.job       Job object to create periodic builds for
      * @param {String} config.apiUri    Base URL of the Screwdriver API
      * @return {Promise}
      */
-    async postBuildEvent({ pipeline, job, apiUri, eventId, causeMessage }) {
+    async postBuildEvent({ pipeline, job, apiUri, eventId, buildId, causeMessage }) {
         const pipelineInstance = await this.pipelineFactory.get(pipeline.id);
         const admin = await pipelineInstance.getFirstAdmin();
         const jwt = this.userTokenGen(admin.username, {}, pipeline.scmContext);
@@ -227,6 +228,10 @@ class ExecutorQueue extends Executor {
 
         if (eventId) {
             options.body.parentEventId = eventId;
+        }
+
+        if (buildId) {
+            options.body.buildId = buildId;
         }
 
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Context

currently event create by freeze window doesn't not have access to original event's metadata, because context was lost during the process. 

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
pass buildId to api end point and treat freeze job as restart case

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
