### PR TITLE
fix: test for response before accessing properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -239,7 +239,7 @@ class ExecutorQueue extends Executor {
                 if (!err && response.statusCode === 201) {
                     return resolve(response);
                 }
-                if (response.statusCode !== 201) {
+                if (response && response.statusCode !== 201) {
                     return reject(JSON.stringify(response.body));
                 }
 

--- a/index.js
+++ b/index.js
@@ -272,7 +272,7 @@ class ExecutorQueue extends Executor {
                     return resolve(response);
                 }
 
-                if (response.statusCode !== 200) {
+                if (response && response.statusCode !== 200) {
                     return reject(JSON.stringify(response.body));
                 }
 


### PR DESCRIPTION
## Context

Noticing API crashes when response is empty. Can happen on errros.

## Objective

fix: add proper checks for response. 

## References
```
TypeError: Cannot read property 'statusCode' of undefined
at Request.<anonymous> (/usr/src/app/node_modules/screwdriver-executor-queue/index.js:242:30)
```

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
