### PR TITLE
fix: Update msg to log job.id

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,11 +27,15 @@ class ExecutorQueue extends Executor {
      * @return {Promise}
      */
     async _startPeriodic(config) {
-        return this.api(config, {
+        const options = {
             path: '/v1/queue/message?type=periodic',
             method: 'POST',
             body: config
-        });
+        };
+
+        logger.info(`${options.method} ${options.path} for pipeline ${config.pipeline.id}:${config.job.id}`);
+
+        return this.api(config, options);
     }
 
     /**
@@ -42,11 +46,15 @@ class ExecutorQueue extends Executor {
      * @return {Promise}
      */
     async _stopPeriodic(config) {
-        return this.api(config, {
+        const options = {
             path: '/v1/queue/message?type=periodic',
             method: 'DELETE',
             body: config
-        });
+        };
+
+        logger.info(`${options.method} ${options.path} for pipeline ${config.pipelineId}:${config.jobId}`);
+
+        return this.api(config, options);
     }
 
     /**
@@ -56,11 +64,15 @@ class ExecutorQueue extends Executor {
      * @return {Promise}
      */
     async _startFrozen(config) {
-        return this.api(config, {
+        const options = {
             path: '/v1/queue/message?type=frozen',
             method: 'POST',
             body: config
-        });
+        };
+
+        logger.info(`${options.method} ${options.path} for pipeline ${config.pipelineId}:${config.jobId}`);
+
+        return this.api(config, options);
     }
 
     /**
@@ -71,11 +83,15 @@ class ExecutorQueue extends Executor {
      * @return {Promise}
      */
     async _stopFrozen(config) {
-        return this.api(config, {
+        const options = {
             path: '/v1/queue/message?type=frozen',
             method: 'DELETE',
             body: config
-        });
+        };
+
+        logger.info(`${options.method} ${options.path} for pipeline ${config.pipelineId}:${config.jobId}`);
+
+        return this.api(config, options);
     }
 
     /**
@@ -88,11 +104,15 @@ class ExecutorQueue extends Executor {
      * @return {Promise}
      */
     async _startTimer(config) {
-        return this.api(config, {
+        const options = {
             path: '/v1/queue/message?type=timer',
             method: 'POST',
             body: config
-        });
+        };
+
+        logger.info(`${options.method} ${options.path} for pipeline ${config.pipelineId}:${config.jobId}`);
+
+        return this.api(config, options);
     }
 
     /**
@@ -103,11 +123,15 @@ class ExecutorQueue extends Executor {
      * @return {Promise}
      */
     async _stopTimer(config) {
-        return this.api(config, {
+        const options = {
             path: '/v1/queue/message?type=timer',
             method: 'DELETE',
             body: config
-        });
+        };
+
+        logger.info(`${options.method} ${options.path} for pipeline ${config.pipelineId}:${config.jobId}`);
+
+        return this.api(config, options);
     }
 
     /**
@@ -133,11 +157,15 @@ class ExecutorQueue extends Executor {
      * @return {Promise}
      */
     async _start(config) {
-        return this.api(config, {
+        const options = {
             path: '/v1/queue/message',
             method: 'POST',
             body: config
-        });
+        };
+
+        logger.info(`${options.method} ${options.path} for pipeline ${config.pipelineId}:${config.jobId}`);
+
+        return this.api(config, options);
     }
 
     /**
@@ -150,11 +178,15 @@ class ExecutorQueue extends Executor {
      * @return {Promise}
      */
     async _stop(config) {
-        return this.api(config, {
+        const options = {
             path: '/v1/queue/message',
             method: 'DELETE',
             body: config
-        });
+        };
+
+        logger.info(`${options.method} ${options.path} for pipeline ${config.pipelineId}:${config.jobId}`);
+
+        return this.api(config, options);
     }
 
     /**
@@ -163,6 +195,8 @@ class ExecutorQueue extends Executor {
      * @param {Response} Object     Object containing stats for the executor
      */
     stats(config) {
+        logger.info('GET /v1/queue/stats for pipeline');
+
         return this.api(config, {
             path: '/v1/queue/stats',
             method: 'GET'
@@ -189,11 +223,6 @@ class ExecutorQueue extends Executor {
             retryStrategy: this.requestRetryStrategy,
             ...args
         };
-
-        logger.info(
-            `${options.method} ${options.path} for pipeline ${config.pipelineId || config.pipeline.id}:${config.jobId ||
-                config.job.id}`
-        );
 
         return new Promise((resolve, reject) => {
             requestretry(options, (err, response) => {

--- a/index.js
+++ b/index.js
@@ -190,7 +190,10 @@ class ExecutorQueue extends Executor {
             ...args
         };
 
-        logger.info(`${options.method} ${options.path} for pipeline ${config.pipelineId}:${config.jobId}`);
+        logger.info(
+            `${options.method} ${options.path} for pipeline ${config.pipelineId || config.pipeline.id}:${config.jobId ||
+                config.job.id}`
+        );
 
         return new Promise((resolve, reject) => {
             requestretry(options, (err, response) => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -79,7 +79,7 @@ describe('index test', () => {
     describe('_startPeriodic', done => {
         it('Calls api to start periodic build', () => {
             mockRequest.yieldsAsync(null, { statusCode: 200 });
-            const periodicConfig = { ...testConfig, username: 'admin' };
+            const periodicConfig = { ...testConfig, username: 'admin', pipeline: { id: 123 }, job: { id: 777 } };
 
             const options = {
                 ...requestOptions,
@@ -235,13 +235,14 @@ describe('index test', () => {
                 jobId: testConfig.jobId,
                 startTime: isoTime,
                 job: testJob,
-                pipeline: testPipeline
+                pipeline: testPipeline,
+                pipelineId: testPipeline.id
             };
 
             sandbox.useFakeTimers(dateNow);
             Object.assign(requestOptions, {
                 url: 'http://localhost/v1/queue/message?type=timer',
-                method: 'DEELTE',
+                method: 'DELETE',
                 body: timerConfig
             });
 
@@ -268,7 +269,8 @@ describe('index test', () => {
                 jobId: testConfig.jobId,
                 startTime: isoTime,
                 job: testJob,
-                pipeline: testPipeline
+                pipeline: testPipeline,
+                pipelineId: testPipeline.id
             };
 
             sandbox.useFakeTimers(dateNow);


### PR DESCRIPTION
## Context

Executor Start/StartPeriodic/Stop functions send params differently so log message shows undefined

## Objective

This PR fixes log message and logs pipeline.id and job.id correctly

## References

It closes PR https://github.com/screwdriver-cd/models/pull/444

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
