### PR TITLE
feat(1958): Publish major version. BREAKING CHANGE: hapi v19

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,17 +34,17 @@
   ],
   "devDependencies": {
     "chai": "^4.2.0",
-    "eslint": "^6.8.0",
-    "eslint-config-screwdriver": "^5.0.3",
-    "mocha": "^7.1.0",
+    "eslint": "^7.7.0",
+    "eslint-config-screwdriver": "^5.0.4",
+    "mocha": "^8.1.1",
     "mockery": "^2.0.0",
     "nyc": "^15.0.0",
     "sinon": "^4.5.0"
   },
   "dependencies": {
     "requestretry": "^3.1.0",
-    "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#hapi-v19",
-    "screwdriver-executor-base": "git://github.com/screwdriver-cd/executor-base.git#hapi-v19",
+    "screwdriver-data-schema": "^20.0.0",
+    "screwdriver-executor-base": "^8.0.0",
     "screwdriver-logger": "^1.0.0",
     "string-hash": "^1.1.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-executor-queue",
-  "version": "4.0.0",
+  "version": "3.0.0",
   "description": "Executor plugin for Screwdriver using Resque",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-executor-queue",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "Executor plugin for Screwdriver using Resque",
   "main": "index.js",
   "scripts": {
@@ -43,8 +43,8 @@
   },
   "dependencies": {
     "requestretry": "^3.1.0",
-    "screwdriver-data-schema": "^19.7.0",
-    "screwdriver-executor-base": "^7.4.0",
+    "screwdriver-data-schema": "git://github.com/screwdriver-cd/data-schema.git#hapi-v19",
+    "screwdriver-executor-base": "git://github.com/screwdriver-cd/executor-base.git#hapi-v19",
     "screwdriver-logger": "^1.0.0",
     "string-hash": "^1.1.3"
   },

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:8
+    image: node:12
 
 jobs:
     main:


### PR DESCRIPTION
## Context

Upgrade to latest hapi js version v19 supported and stable version

## Objective

This PR publishes a new version of the package

## References

https://github.com/screwdriver-cd/screwdriver/issues/1958

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.