### PR TITLE
feat(1961): Replace deprecated request package

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "Tiffany Kyi <tiffanykyi@gmail.com>"
   ],
   "devDependencies": {
-    "chai": "^4.2.0",
+    "chai": "^4.3.4",
     "eslint": "^7.7.0",
     "eslint-config-screwdriver": "^5.0.4",
     "mocha": "^8.2.1",
@@ -44,10 +44,10 @@
     "sinon": "^4.5.0"
   },
   "dependencies": {
-    "requestretry": "^3.1.0",
     "screwdriver-data-schema": "^21.0.0",
     "screwdriver-executor-base": "^8.0.0",
     "screwdriver-logger": "^1.0.0",
+    "screwdriver-request": "^1.0.3",
     "string-hash": "^1.1.3"
   },
   "release": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -32,7 +32,7 @@ describe('index test', () => {
             token: 'admintoken'
         });
         mockRequest = sinon.stub();
-        mockery.registerMock('requestretry', mockRequest);
+        mockery.registerMock('screwdriver-request', mockRequest);
 
         /* eslint-disable global-require */
         Executor = require('../index');
@@ -48,11 +48,14 @@ describe('index test', () => {
                 Authorization: 'Bearer admintoken',
                 'Content-Type': 'application/json'
             },
-            json: true,
             body: testConfig,
-            maxAttempts: 3,
-            retryDelay: 5000,
-            retryStrategy: executor.requestRetryStrategy
+            retryOptions: {
+                limit: 3,
+                calculateDelay: ({ computedValue }) => (computedValue ? 5000 : 0)
+            },
+            hooks: {
+                afterResponse: [executor.requestRetryStrategy]
+            }
         };
     });
 
@@ -78,7 +81,7 @@ describe('index test', () => {
 
     describe('_startPeriodic', done => {
         it('Calls api to start periodic build', () => {
-            mockRequest.yieldsAsync(null, { statusCode: 200 });
+            mockRequest.resolves({ statusCode: 200 });
             const periodicConfig = { ...testConfig, username: 'admin', pipeline: { id: 123 }, job: { id: 777 } };
 
             const options = {
@@ -98,7 +101,7 @@ describe('index test', () => {
 
     describe('_stopPeriodic', done => {
         it('Calls api to stop periodic build', () => {
-            mockRequest.yieldsAsync(null, { statusCode: 200 });
+            mockRequest.resolves({ statusCode: 200 });
 
             const options = {
                 ...requestOptions,
@@ -117,7 +120,7 @@ describe('index test', () => {
 
     describe('_start', done => {
         it('Calls api to start build', () => {
-            mockRequest.yieldsAsync(null, { statusCode: 200 });
+            mockRequest.resolves({ statusCode: 200 });
             const startConfig = { ...testConfig, pipeline: testPipeline };
 
             Object.assign(requestOptions, {
@@ -136,7 +139,7 @@ describe('index test', () => {
 
     describe('_startFrozen', done => {
         it('Calls api to start frozen build', () => {
-            mockRequest.yieldsAsync(null, { statusCode: 200 });
+            mockRequest.resolves({ statusCode: 200 });
 
             Object.assign(requestOptions, {
                 url: 'http://localhost/v1/queue/message?type=frozen',
@@ -154,7 +157,7 @@ describe('index test', () => {
 
     describe('_stopFrozen', done => {
         it('Calls api to stop frozen builds', () => {
-            mockRequest.yieldsAsync(null, { statusCode: 200 });
+            mockRequest.resolves({ statusCode: 200 });
 
             Object.assign(requestOptions, {
                 url: 'http://localhost/v1/queue/message?type=frozen',
@@ -172,7 +175,7 @@ describe('index test', () => {
 
     describe('_stop', done => {
         it('Calls api to stop a build', () => {
-            mockRequest.yieldsAsync(null, { statusCode: 200 });
+            mockRequest.resolves({ statusCode: 200 });
             const stopConfig = {
                 annotations: testConfig.annotations,
                 blockedBy: testConfig.blockedBy,
@@ -200,7 +203,7 @@ describe('index test', () => {
 
     describe('stats', done => {
         it('Calls api to get stats', () => {
-            mockRequest.yieldsAsync(null, { statusCode: 200 });
+            mockRequest.resolves({ statusCode: 200 });
             const statsConfig = {
                 buildId: testConfig.buildId,
                 jobId: testConfig.jobId,
@@ -213,7 +216,7 @@ describe('index test', () => {
                 method: 'GET'
             });
 
-            mockRequest.yieldsAsync(null, { body: 'Hello', statusCode: 200 });
+            mockRequest.resolves({ body: 'Hello', statusCode: 200 });
 
             return executor.stats(statsConfig, (err, res) => {
                 assert.calledWithArgs(mockRequest, {}, requestOptions);
@@ -226,7 +229,7 @@ describe('index test', () => {
 
     describe('_stopTimer', done => {
         it('Calls api to stop timer', () => {
-            mockRequest.yieldsAsync(null, { statusCode: 200 });
+            mockRequest.resolves({ statusCode: 200 });
             const dateNow = Date.now();
             const isoTime = new Date(dateNow).toISOString();
             const sandbox = sinon.sandbox.create({
@@ -261,7 +264,7 @@ describe('index test', () => {
 
     describe('_startTimer', done => {
         it('Calls api to start timer', () => {
-            mockRequest.yieldsAsync(null, { statusCode: 200 });
+            mockRequest.resolves({ statusCode: 200 });
             const dateNow = Date.now();
             const isoTime = new Date(dateNow).toISOString();
             const sandbox = sinon.sandbox.create({


### PR DESCRIPTION
## Context

It would be nice to replace deprecated request package with a different one.

## Objective

This PR attempts to replace [request package](https://www.npmjs.com/package/request) with [got package](https://github.com/sindresorhus/got).

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1961

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.