### PR TITLE
fix: unhandled issue with got pkg

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -48,11 +48,14 @@ describe('index test', () => {
                 Authorization: 'Bearer admintoken',
                 'Content-Type': 'application/json'
             },
-            json: true,
-            body: testConfig,
-            maxAttempts: 3,
-            retryDelay: 5000,
-            retryStrategy: executor.requestRetryStrategy
+            json: testConfig,
+            limit: 3,
+            calculateDelay: () => {
+                return 5000;
+            },
+            hooks: {
+                afterResponse: executor.requestRetryStrategy
+            }
         };
     });
 
@@ -85,7 +88,7 @@ describe('index test', () => {
                 ...requestOptions,
                 url: 'http://localhost/v1/queue/message?type=periodic',
                 method: 'POST',
-                body: periodicConfig
+                json: periodicConfig
             };
 
             return executor.startPeriodic(periodicConfig, err => {
@@ -104,7 +107,7 @@ describe('index test', () => {
                 ...requestOptions,
                 url: 'http://localhost/v1/queue/message?type=periodic',
                 method: 'DELETE',
-                body: testConfig
+                json: testConfig
             };
 
             return executor.stopPeriodic(testConfig, err => {
@@ -123,7 +126,7 @@ describe('index test', () => {
             Object.assign(requestOptions, {
                 url: 'http://localhost/v1/queue/message',
                 method: 'POST',
-                body: startConfig
+                json: startConfig
             });
 
             return executor.start(startConfig, err => {
@@ -141,7 +144,7 @@ describe('index test', () => {
             Object.assign(requestOptions, {
                 url: 'http://localhost/v1/queue/message?type=frozen',
                 method: 'POST',
-                body: testConfig
+                json: testConfig
             });
 
             return executor.startFrozen(testConfig, err => {
@@ -159,7 +162,7 @@ describe('index test', () => {
             Object.assign(requestOptions, {
                 url: 'http://localhost/v1/queue/message?type=frozen',
                 method: 'DELETE',
-                body: testConfig
+                json: testConfig
             });
 
             return executor.stopFrozen(testConfig, err => {
@@ -187,7 +190,7 @@ describe('index test', () => {
             Object.assign(requestOptions, {
                 url: 'http://localhost/v1/queue/message',
                 method: 'DELETE',
-                body: stopConfig
+                json: stopConfig
             });
 
             executor.stop(stopConfig, err => {
@@ -213,7 +216,7 @@ describe('index test', () => {
                 method: 'GET'
             });
 
-            mockRequest.yieldsAsync(null, { body: 'Hello', statusCode: 200 });
+            mockRequest.yieldsAsync(null, { json: 'Hello', statusCode: 200 });
 
             return executor.stats(statsConfig, (err, res) => {
                 assert.calledWithArgs(mockRequest, {}, requestOptions);
@@ -247,7 +250,7 @@ describe('index test', () => {
             Object.assign(requestOptions, {
                 url: 'http://localhost/v1/queue/message?type=timer',
                 method: 'DELETE',
-                body: timerConfig
+                json: timerConfig
             });
 
             return executor.stopTimer(timerConfig, err => {
@@ -282,7 +285,7 @@ describe('index test', () => {
             Object.assign(requestOptions, {
                 url: 'http://localhost/v1/queue/message?type=timer',
                 method: 'POST',
-                body: testConfig
+                json: testConfig
             });
 
             return executor.startTimer(timerConfig, err => {


### PR DESCRIPTION
## Context

SD pipeline was failing with 500 (Internal server error) due to an error with executor-queue not using the correct `got` request format

## Objective

This PR fixes the format as per `screwdriver-request(got)` pkg

## References

Related to https://github.com/screwdriver-cd/executor-queue/pull/94

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
