### PR TITLE
fix(1961): Retry with new request package

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,9 +9,9 @@ const RETRY_DELAY = 5;
 class ExecutorQueue extends Executor {
     constructor(config = {}) {
         super();
-        this.requestRetryStrategy = (response, retryWithMergedOptions) => {
+        this.requestRetryStrategy = response => {
             if (response.statusCode !== 201 && response.statusCode !== 200) {
-                retryWithMergedOptions({});
+                throw new Error('Retry limit reached');
             }
 
             return response;
@@ -220,7 +220,7 @@ class ExecutorQueue extends Executor {
                 'Content-Type': 'application/json'
             },
             url: `${this.queueUri}${args.path}`,
-            retryOptions: {
+            retry: {
                 limit: RETRY_LIMIT,
                 calculateDelay: ({ computedValue }) => (computedValue ? RETRY_DELAY * 1000 : 0) // in ms
             },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -49,7 +49,7 @@ describe('index test', () => {
                 'Content-Type': 'application/json'
             },
             body: testConfig,
-            retryOptions: {
+            retry: {
                 limit: 3,
                 calculateDelay: ({ computedValue }) => (computedValue ? 5000 : 0)
             },


### PR DESCRIPTION
## Context

Retry requires error to be thrown to trigger properly.

## Objective

This PR:
- renames from `retryOptions` => `retry`
- throws error in retry strategy in `afterResponse` hook to correctly trigger retries
- 
## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/1961

## License
I confirm that this contribution is made under a BSD license and that I have the authority necessary to make this contribution on behalf of its copyright owner.