### PR TITLE
fix(1500): [2] add unzipArtifacts method

### DIFF
--- a/index.js
+++ b/index.js
@@ -134,6 +134,24 @@ class ExecutorQueue extends Executor {
     }
 
     /**
+     * Unzip the ZIP of artifacts
+     * @method _unzipArtifacts
+     * @param  {Object}  config           Configuration
+     * @param  {Integer} config.buildId   Unique ID for a build
+     * @return {Promise}
+     */
+    async _unzipArtifacts(config) {
+        const options = {
+            path: '/v1/queue/message?type=unzip',
+            method: 'POST'
+        }
+
+        logger.info(`${options.method} ${options.path} for artifacts of build:${config.buildId}`);
+
+        return this.api(config, options);
+    }
+
+    /**
      * Starts a new build in an executor
      * @async  _start
      * @param  {Object} config               Configuration

--- a/index.js
+++ b/index.js
@@ -144,7 +144,7 @@ class ExecutorQueue extends Executor {
         const options = {
             path: '/v1/queue/message?type=unzip',
             method: 'POST'
-        }
+        };
 
         logger.info(`${options.method} ${options.path} for artifacts of build:${config.buildId}`);
 

--- a/index.js
+++ b/index.js
@@ -137,7 +137,8 @@ class ExecutorQueue extends Executor {
      * Unzip the ZIP of artifacts
      * @method _unzipArtifacts
      * @param  {Object}  config           Configuration
-     * @param  {Integer} config.buildId   Unique ID for a build
+     * @param  {Number}  config.buildId   Unique ID for a build
+     * @param  {String}  config.token     JWT to act on behalf of the build
      * @return {Promise}
      */
     async _unzipArtifacts(config) {

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "pretest": "eslint .",
     "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "./node_modules/.bin/semantic-release"
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:screwdriver-cd/executor-queue.git"
+    "url": "git+https://github.com/screwdriver-cd/executor-queue.git"
   },
   "homepage": "https://github.com/screwdriver-cd/executor-queue",
   "bugs": "https://github.com/screwdriver-cd/screwdriver/issues",
@@ -51,6 +51,9 @@
     "string-hash": "^1.1.3"
   },
   "release": {
+    "branches": [
+      "master"
+    ],
     "debug": false,
     "verifyConditions": {
       "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -173,6 +173,24 @@ describe('index test', () => {
         });
     });
 
+    describe('_unzipArtifacts', done => {
+        it('Calls api to unzip build artifacts', () => {
+            mockRequest.resolves({ statusCode: 200 });
+
+            Object.assign(requestOptions, {
+                url: 'http://localhost/v1/queue/message?type=unzip',
+                method: 'POST',
+                json: { buildId: 1234 }
+            });
+
+            return executor.unzipArtifacts({ buildId: 1234 }, err => {
+                assert.calledWithArgs(mockRequest, testConfig, requestOptions);
+                assert.isNull(err);
+                done();
+            });
+        });
+    });
+
     describe('_stop', done => {
         it('Calls api to stop a build', () => {
             mockRequest.resolves({ statusCode: 200 });


### PR DESCRIPTION
## Context
To implement SD_ZIP_ARTIFACTS feature by [new design](https://github.com/screwdriver-cd/screwdriver/blob/0962d20d251c0b7c03d40b7e4b10bb1ed009831d/design/sd-zip-artifacts.md)

Please refer the following for the progress of this feature.
https://github.com/screwdriver-cd/screwdriver/issues/1500#issuecomment-998382248

## Objective
This PR add a new method to request for queue-service to unzip artifacts.

note: this PR build should be failed until [executor-base](https://github.com/screwdriver-cd/executor-base/pull/75) will be updated.

## References
This PR depends on following PR.
- https://github.com/screwdriver-cd/executor-base/pull/75

[design doc](https://github.com/screwdriver-cd/screwdriver/blob/0962d20d251c0b7c03d40b7e4b10bb1ed009831d/design/sd-zip-artifacts.md#sd-api-api)

[issue](https://github.com/screwdriver-cd/screwdriver/issues/1500)

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
