### PR TITLE
fix: Remove noop for semantic release

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,9 +54,6 @@
     "branches": [
       "master"
     ],
-    "debug": false,
-    "verifyConditions": {
-      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
-    }
+    "debug": false
   }
 }


### PR DESCRIPTION
## Context

Seeing `Error: Cannot find module './node_modules/semantic-release/src/lib/plugin-noop.js'`
## Objective

This PR removes old package.json section for noop plugin.

## References
Related to https://github.com/screwdriver-cd/data-schema/pull/466

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
