### PR TITLE
feat(1769): [2] Add _enqueueWebhook method for queue-service cooperation

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,6 +153,24 @@ class ExecutorQueue extends Executor {
     }
 
     /**
+     * Enqueue webhookConfig to queue service
+     * @method _enqueueWebhook
+     * @param  {Object}  config           Configuration
+     * @param  {String}  config.token     JWT to call api
+     * @return {Promise}
+     */
+    async _enqueueWebhook(config) {
+        const options = {
+            path: '/v1/queue/message?type=webhook',
+            method: 'POST'
+        };
+
+        logger.info(`${options.method} ${options.path} for hookId:${config.hookId}`);
+
+        return this.api(config, options);
+    }
+
+    /**
      * Starts a new build in an executor
      * @async  _start
      * @param  {Object} config               Configuration

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -191,6 +191,24 @@ describe('index test', () => {
         });
     });
 
+    describe('_enqueueWebhook', done => {
+        it('Calls api to enqueue webhookConfig', () => {
+            mockRequest.resolves({ statusCode: 200 });
+
+            Object.assign(requestOptions, {
+                url: 'http://localhost/v1/queue/message?type=webhook',
+                method: 'POST',
+                json: { hookId: 1234 }
+            });
+
+            return executor.enqueueWebhook({ hookId: 1234 }, err => {
+                assert.calledWithArgs(mockRequest, testConfig, requestOptions);
+                assert.isNull(err);
+                done();
+            });
+        });
+    });
+
     describe('_stop', done => {
         it('Calls api to stop a build', () => {
             mockRequest.resolves({ statusCode: 200 });


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
This is the implementation that follows https://github.com/screwdriver-cd/screwdriver/pull/2622.
Implemented a method to pass the webhookConfig from SCM to the queue service endpoint `/v1/queue/message?type=webhook`.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Added `_enqueueWebhook` method called by the [SD API](https://github.com/screwdriver-cd/screwdriver/pull/2627/files#diff-ac1c92f80ed73064b1f05c0d334dac456ec9692ce2e3270757507ed76db5b0f2R91).

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
The test fail until the `enqueueWebhook` method is added to the super class.
Please do not merge this PR unti the [leading PR](https://github.com/screwdriver-cd/executor-base/pull/77) have been merged.

Related PR:
- https://github.com/screwdriver-cd/executor-base/pull/77
- https://github.com/screwdriver-cd/screwdriver/pull/2627

https://github.com/screwdriver-cd/screwdriver/issues/1769#issuecomment-934107626

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
