### PR TITLE
fix(3055): remove k8s-vm name from README.md [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 > An executor plugin that routes builds through a Redis queue
 
-The executor-queue for Screwdriver will push new jobs into a Redis queue. Other executors such as [executor-docker](https://github.com/screwdriver-cd/executor-docker),  [executor-k8s](https://github.com/screwdriver-cd/executor-k8s) and [executor-k8s-vm](https://github.com/screwdriver-cd/executor-k8s-vm) will process jobs from this queue.
+The executor-queue for Screwdriver will push new jobs into a Redis queue. Other executors such as [executor-docker](https://github.com/screwdriver-cd/executor-docker) and [executor-k8s](https://github.com/screwdriver-cd/executor-k8s) will process jobs from this queue.
 
 ## Usage
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

[executor-k8s-vm](https://github.com/screwdriver-cd/executor-k8s-vm) has been archived.
We need to remove this package dependence from active repositories.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Remove `executor-k8s-vm` from this repository.
This repository is not dependent on `k8s-vm`, but this repository includes `k8s-vm` name in the README.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://github.com/screwdriver-cd/screwdriver/issues/3055

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
